### PR TITLE
Resolve issue #11

### DIFF
--- a/Translation/Updater.php
+++ b/Translation/Updater.php
@@ -103,7 +103,7 @@ class Updater
     {
         $catalogue = $this->loader->loadFile($file, $format, $locale, $domain);
         $catalogue
-            ->get($id)
+            ->get($id, $domain)
             ->setLocaleString($trans)
             ->setNew(false)
         ;


### PR DESCRIPTION
Fix bug => Translator UI crash if you have no file for the domaine "message". Add the domaine to the $message->get() call
