### PR TITLE
Fix DefaultApplyingNodeVisitor when |trans has replacement param

### DIFF
--- a/Tests/Twig/Fixture/apply_default_value_compiled.html.twig
+++ b/Tests/Twig/Fixture/apply_default_value_compiled.html.twig
@@ -1,4 +1,4 @@
 {{ "form.label.firstname"|trans == "form.label.firstname" ? "Firstname" : "form.label.firstname"|trans }}
 
-{{ "foo.%bar%"|trans({}) == "foo.%bar%" ? "Foo %bar%"|jms_translation_strtr({"%bar%": "baz"}) : "foo.%bar%"|trans({"%bar%": "baz"}) }}
+{{ "foo.%bar%"|trans({}) == "foo.%bar%" ? "Foo %bar%"|replace({"%bar%": "baz"}) : "foo.%bar%"|trans({"%bar%": "baz"}) }}
 

--- a/Twig/DefaultApplyingNodeVisitor.php
+++ b/Twig/DefaultApplyingNodeVisitor.php
@@ -76,7 +76,7 @@ class DefaultApplyingNodeVisitor implements \Twig_NodeVisitorInterface
 
                 $defaultNode = new \Twig_Node_Expression_Filter(
                     clone $node->getNode('arguments')->getNode(0),
-                    new \Twig_Node_Expression_Constant('jms_translation_strtr', $lineno),
+                    new \Twig_Node_Expression_Constant('replace', $lineno),
                     new \Twig_Node(array(
                         clone $wrappingNode->getNode('arguments')->getNode(0)
                     )),

--- a/Twig/TranslationExtension.php
+++ b/Twig/TranslationExtension.php
@@ -51,7 +51,6 @@ class TranslationExtension extends \Twig_Extension
         return array(
             'desc' => new \Twig_Filter_Method($this, 'desc'),
             'meaning' => new \Twig_Filter_Method($this, 'meaning'),
-            'jms_translation_strtr' => new \Twig_Filter_Function('strtr'),
         );
     }
 


### PR DESCRIPTION
This fixes two issues with the `|trans|desc` filters:
1. `'%foo%'|trans({'%foo%': 'bar'})|desc('Default')` won't print the default translation because `'%foo%'|trans({'%foo%': 'bar'}) != '%foo%'`
2. `'foo'|trans({'%foo%': 'bar'})|desc('%foo%')` will not replace the `%placeholders%` when printing the default value
