### PR TITLE
don't pass the message id in the URL (workaround for https://github.com/symfony/symfony/issues/2962 )

### DIFF
--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -28,6 +28,7 @@ use JMS\TranslationBundle\Util\FileUtils;
 use JMS\DiExtraBundle\Annotation as DI;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @Route("/api")
@@ -46,14 +47,16 @@ class ApiController
     private $updater;
 
     /**
-     * @Route("/configs/{config}/domains/{domain}/locales/{locale}/messages/{id}",
+     * @Route("/configs/{config}/domains/{domain}/locales/{locale}/messages",
      * 			name="jms_translation_update_message",
      * 			defaults = {"id" = null},
      * 			options = {"i18n" = false})
      * @Method("PUT")
      */
-    public function updateMessageAction($config, $domain, $locale, $id)
+    public function updateMessageAction(Request $request, $config, $domain, $locale)
     {
+        $id = $request->query->get('id');
+
         $config = $this->configFactory->getConfig($config, $locale);
 
         $files = FileUtils::findTranslationFiles($config->getTranslationsDir());

--- a/Resources/views/Translate/index.html.twig
+++ b/Resources/views/Translate/index.html.twig
@@ -15,7 +15,7 @@
             $('textarea')
                 .blur(function() {
                     var self = this;
-                    $.ajax(updateMessagePath + '/' + encodeURIComponent($(this).data('id')), {
+                    $.ajax(updateMessagePath + '?id=' + encodeURIComponent($(this).data('id')), {
                         type: 'POST',
                         data: {'_method': 'PUT', 'message': $(this).val()},
                         error: function() {


### PR DESCRIPTION
A message is updated by posting to /configs/{config}/domains/{domain}/locales/{locale}/messages/{id}; however when the id contains `%` chars (e.g. %abc%), symfony urldecodes it 3 times, and updating the message fails ( see https://github.com/symfony/symfony/issues/2962 ).

This PR passes the message id in the query string instead, to workaround this problem.
