### PR TITLE
Changed the XLIFF dumper so that it supports CDATA for target and source

### DIFF
--- a/Translation/Dumper/XliffDumper.php
+++ b/Translation/Dumper/XliffDumper.php
@@ -121,10 +121,18 @@ class XliffDumper implements DumperInterface
             }
 
             $unit->appendChild($source = $doc->createElement('source'));
-            $source->appendChild($doc->createCDATASection($message->getSourceString()));
+            if(preg_match('/[<>&]/', $message->getSourceString())) {
+                $source->appendChild($doc->createCDATASection($message->getSourceString()));
+            } else {
+                $source->appendChild($doc->createTextNode($message->getSourceString()));
+            }
 
             $unit->appendChild($target = $doc->createElement('target'));
-            $target->appendChild($doc->createCDATASection($message->getLocaleString()));
+            if(preg_match('/[<>&]/', $message->getLocaleString())) {
+                $source->appendChild($doc->createCDATASection($message->getLocaleString()));
+            } else {
+                $source->appendChild($doc->createTextNode($message->getLocaleString()));
+            }
 
             if ($message->isNew()) {
                 $target->setAttribute('state', 'new');


### PR DESCRIPTION
Hello,

I've found this to be quite useful during the development of our project. CDATA sections are very important for us and XLIFF should support them natively.

What do you think?
