### PR TITLE
Fix "Argument 7 passed (...) must be an array, null given"

### DIFF
--- a/Translation/ConfigBuilder.php
+++ b/Translation/ConfigBuilder.php
@@ -26,7 +26,7 @@ final class ConfigBuilder
     private $domains = array();
     private $outputFormat;
     private $defaultOutputFormat = 'xliff';
-    private $scanDirs;
+    private $scanDirs = array();
     private $excludedDirs = array('Tests');
     private $excludedNames = array('*Test.php', '*TestCase.php');
     private $enabledExtractors = array();


### PR DESCRIPTION
It occurs when "app/console translation:extract" is called without a --dir parameter
