### PR TITLE
Specify a php-parser version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "2.*",
-        "nikic/php-parser" : "*"
+        "nikic/php-parser" : "0.9.1"
     },
     "suggest": {
     	"twig/twig":  "1.*",


### PR DESCRIPTION
I did some BC breaking changes in the parser, so it would be better to specify 0.9.1 explicitly :)
