### PR TITLE
Support labels for "repeated" field groups

### DIFF
--- a/Tests/Translation/Extractor/File/Fixture/MyFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormType.php
@@ -37,6 +37,14 @@ class MyFormType extends AbstractType
                 'empty_value' => /** @Desc("Please select a state") */ 'form.states.empty_value',
             ))
             ->add('countries', 'choice', array('empty_value' => false))
+            ->add('password', 'repeated', array(
+                'first_options' => array(
+                  'label' => 'form.label.password'
+                ),
+                'second_options' => array(
+                  'label' => /** @Desc("Repeat password") */ 'form.label.password_repeated'
+                ),
+            ))
         ;
     }
 }

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -51,6 +51,15 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
         $message->addSource(new FileSource($path, 30));
         $expected->add($message);
 
+        $message = new Message('form.label.password');
+        $message->addSource(new FileSource($path, 42));
+        $expected->add($message);
+
+        $message = new Message('form.label.password_repeated');
+        $message->setDesc('Repeat password');
+        $message->addSource(new FileSource($path, 45));
+        $expected->add($message);
+
         $this->assertEquals($expected, $this->extract('MyFormType.php'));
     }
 

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -150,13 +150,27 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
                     continue;
                 }
 
-                if ('label' !== $item->key->value && 'empty_value' !== $item->key->value && 'choices' !== $item->key->value) {
+                if ('first_options' === $item->key->value && !$item->value instanceof \PHPParser_Node_Expr_Array) {
+                    continue;
+                }
+
+                if ('second_options' === $item->key->value && !$item->value instanceof \PHPParser_Node_Expr_Array) {
+                    continue;
+                }
+
+                if ('label' !== $item->key->value && 'empty_value' !== $item->key->value && 'choices' !== $item->key->value && 'first_options' !== $item->key->value && 'second_options' !== $item->key->value) {
                     continue;
                 }
 
                 if ('choices' === $item->key->value) {
                     foreach ($item->value->items as $sitem) {
                         $this->parseItem($sitem);
+                    }
+                } elseif ('first_options' === $item->key->value || 'second_options' === $item->key->value) {
+                    foreach ($item->value->items as $sitem) {
+                        if ('label' == $sitem->key->value) {
+                          $this->parseItem($sitem);
+                        }
                     }
                 } else {
                     $this->parseItem($item);


### PR DESCRIPTION
The FormExtractor should support standard Symfony functionality as the "repeated" field group.

This has been suggested before (in e.g. PR #19) but rejected because it's only cleanly supportable in Symfony 2.1, whiich is now nearing completion.

The code is getting a little ugly and I could rewrite it into a `switch` statement if you think that's right.
