### PR TITLE
Support translation_domain option on forms

### DIFF
--- a/Tests/Translation/Extractor/File/Fixture/MyFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormType.php
@@ -45,6 +45,10 @@ class MyFormType extends AbstractType
                   'label' => /** @Desc("Repeat password") */ 'form.label.password_repeated'
                 ),
             ))
+            ->add('street', 'text', array(
+                'label' => /** @Desc("Street") */ 'form.label.street',
+                'translation_domain' => 'address'
+            ))
         ;
     }
 }

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -60,6 +60,12 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
         $message->addSource(new FileSource($path, 45));
         $expected->add($message);
 
+        $message = new Message('form.label.street', 'address');
+        $message->setDesc('Street');
+        $message->addSource(new FileSource($path, 49));
+        $expected->add($message);
+
+
         $this->assertEquals($expected, $this->extract('MyFormType.php'));
     }
 


### PR DESCRIPTION
As mentioned in #61, support for the `translation_domain` option should probably be added.

The current commit only supports the `translation_domain` for field specific options.

The form level `translation_domain` option that is set in `setDefaultOptions` isn't parsed yet, but is something I feel we should support. However, as we can't change the domain on a `Message` afterwards, messages can only be created if their domain is known. Therefore we should either do:
- a 2-pass visit (probably a little complex)
- keep all message details locally and create the actual `Message` at the end of visiting the file.

@schmittjoh: What would you think is the best option?

The form level `translation_domain` option that can be inherited from parent forms (see https://github.com/symfony/symfony/pull/4328 ) is probably not something we can statically extract, right?
