### PR TITLE
Extract invalid_message option for repeated field type

### DIFF
--- a/Tests/Translation/Extractor/File/Fixture/MyFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormType.php
@@ -44,6 +44,7 @@ class MyFormType extends AbstractType
                 'second_options' => array(
                   'label' => /** @Desc("Repeat password") */ 'form.label.password_repeated'
                 ),
+                'invalid_message' => /** @Desc("The entered passwords do not match") */ 'form.error.password_mismatch'
             ))
         ;
     }

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -60,6 +60,11 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
         $message->addSource(new FileSource($path, 45));
         $expected->add($message);
 
+        $message = new Message('form.error.password_mismatch');
+        $message->setDesc('The entered passwords do not match');
+        $message->addSource(new FileSource($path, 47));
+        $expected->add($message);
+
         $this->assertEquals($expected, $this->extract('MyFormType.php'));
     }
 

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -158,7 +158,7 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
                     continue;
                 }
 
-                if ('label' !== $item->key->value && 'empty_value' !== $item->key->value && 'choices' !== $item->key->value && 'first_options' !== $item->key->value && 'second_options' !== $item->key->value) {
+                if ('label' !== $item->key->value && 'empty_value' !== $item->key->value && 'choices' !== $item->key->value && 'first_options' !== $item->key->value && 'second_options' !== $item->key->value && 'invalid_message' !== $item->key->value) {
                     continue;
                 }
 


### PR DESCRIPTION
In PR 55 I missed the specific option for the repeated field types that defines the message to show when the 2 inputs don't match.

This PR adds support for that message.
