### PR TITLE
Use the "validators" domain for the "invalid_message" options in forms.

### DIFF
--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -65,7 +65,7 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
         $message->addSource(new FileSource($path, 50));
         $expected->add($message);
 
-        $message = new Message('form.error.password_mismatch');
+        $message = new Message('form.error.password_mismatch', 'validators');
         $message->setDesc('The entered passwords do not match');
         $message->addSource(new FileSource($path, 47));
         $expected->add($message);

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -189,6 +189,8 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
                           $this->parseItem($sitem, $domain);
                         }
                     }
+                } elseif ('invalid_message' === $item->key->value) {
+                    $this->parseItem($item, 'validators');
                 } else {
                     $this->parseItem($item, $domain);
                 }


### PR DESCRIPTION
As discussed in PR #64, invalid_message probably ends up in a form error display which is translated with the "validators" domain.  The message should end up in "validators" domain too.
