### PR TITLE
Bugfix in RuntimeException when when trying to load an incorrectly formatted XML

### DIFF
--- a/Translation/Loader/XliffLoader.php
+++ b/Translation/Loader/XliffLoader.php
@@ -30,7 +30,7 @@ class XliffLoader implements LoaderInterface
         $previous = libxml_use_internal_errors(true);
         if (false === $doc = simplexml_load_file($resource)) {
             libxml_use_internal_errors($previous);
-			$libxmlError = libxml_get_last_error();
+            $libxmlError = libxml_get_last_error();
 
             throw new RuntimeException(sprintf('Could not load XML-file "%s": %s', $resource, $libxmlError->message));
         }


### PR DESCRIPTION
The RuntimeException was trying to use a LibXMLError object as a string (in the sprintf call).
The "message" property is now used instead so it displays the proper error.
