### PR TITLE
The Desc attribute can now be one line before call to trans or transChoice. The same applies to forms.

### DIFF
--- a/Tests/Translation/Extractor/File/DefaultPhpFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/DefaultPhpFileExtractorTest.php
@@ -58,6 +58,11 @@ class DefaultPhpFileExtractorTest extends BasePhpFileExtractorTest
         $message->addSource(new FileSource($path, 76));
         $expected->add($message);
 
+        $message = new Message('text.var.assign');
+        $message->setDesc('The var %foo% should be assigned.');
+        $message->addSource(new FileSource($path, 82));
+        $expected->add($message);
+
         $this->assertEquals($expected, $catalogue);
     }
 

--- a/Tests/Translation/Extractor/File/Fixture/Controller.php
+++ b/Tests/Translation/Extractor/File/Fixture/Controller.php
@@ -75,4 +75,10 @@ class Controller
     {
         $arr['foo']->trans('text.array_method_call');
     }
+
+    public function assignToVar()
+    {
+        /** @Desc("The var %foo% should be assigned.") */
+        return $this->translator->trans('text.var.assign', array('%foo%' => 'fooVar'));
+    }
 }

--- a/Tests/Translation/Extractor/File/Fixture/MyFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormType.php
@@ -50,6 +50,11 @@ class MyFormType extends AbstractType
                 'label' => /** @Desc("Street") */ 'form.label.street',
                 'translation_domain' => 'address'
             ))
+            ->add('zip', 'text', array(
+                /** @Desc("ZIP") */
+                'label' => 'form.label.zip',
+                'translation_domain' => 'address'
+            ))
         ;
     }
 }

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -70,6 +70,11 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
         $message->addSource(new FileSource($path, 50));
         $expected->add($message);
 
+        $message = new Message('form.label.zip', 'address');
+        $message->setDesc('ZIP');
+        $message->addSource(new FileSource($path, 55));
+        $expected->add($message);
+
         $message = new Message('form.error.password_mismatch', 'validators');
         $message->setDesc('The entered passwords do not match');
         $message->addSource(new FileSource($path, 47));
@@ -86,7 +91,7 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
     {
         $expected = new MessageCatalogue();
         $path = __DIR__.'/Fixture/MyFormTypeWithInterface.php';
-        
+
         $message = new Message('bar');
         $message->addSource(new FileSource($path, 36));
         $expected->add($message);

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -272,7 +272,9 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
         // get doc comment
         $ignore = false;
         $desc = $meaning = null;
-        if ($docComment = $item->value->getDocComment()) {
+        $docComment = $item->key->getDocComment();
+        $docComment = $docComment ? $docComment : $item->value->getDocComment();
+        if ($docComment) {
             foreach ($this->docParser->parse($docComment, 'file '.$this->file.' near line '.$item->value->getLine()) as $annot) {
                 if ($annot instanceof Ignore) {
                     $ignore = true;


### PR DESCRIPTION
This one fixes #16
