### PR TITLE
Fixe scan directories multiple times

### DIFF
--- a/Translation/ExtractorManager.php
+++ b/Translation/ExtractorManager.php
@@ -67,6 +67,8 @@ class ExtractorManager implements ExtractorInterface
      */
     public function setDirectories(array $directories)
     {
+        $this->directories = array();
+        
         foreach ($directories as $dir) {
             $this->addDirectory($dir);
         }


### PR DESCRIPTION
setDirectories is in fact adding directories, not setting them
fixes #97
The only place where the method is used is in Updater.php so it should not break anything ...
