### PR TITLE
Output of dry run improved

### DIFF
--- a/Command/ExtractTranslationCommand.php
+++ b/Command/ExtractTranslationCommand.php
@@ -99,12 +99,22 @@ class ExtractTranslationCommand extends ContainerAwareCommand
             if ($input->getOption('dry-run')) {
                 $changeSet = $updater->getChangeSet($config);
 
-                $output->writeln('Added Messages: '.implode(', ', array_keys($changeSet->getAddedMessages())));
+                $output->writeln('Added Messages: '.count($changeSet->getAddedMessages()));
+                if($input->hasParameterOption('--verbose')){
+                    foreach($changeSet->getAddedMessages() as $message){
+                        $output->writeln($message->getId(). '-> '.$message->getDesc());
+                    }   
+                }
 
                 if ($config->isKeepOldMessages()) {
                     $output->writeln('Deleted Messages: # none as "Keep Old Translations" is true #');
                 } else {
-                    $output->writeln('Deleted Messages: '.implode(', ', array_keys($changeSet->getDeletedMessages())));
+                    $output->writeln('Deleted Messages: '.count($changeSet->getDeletedMessages()));
+                    if($input->hasParameterOption('--verbose')){
+                        foreach($changeSet->getDeletedMessages() as $message){
+                            $output->writeln($message->getId(). '-> '.$message->getDesc());
+                        }   
+                    }
                 }
 
                 return;

--- a/Tests/Functional/ExtractCommandTest.php
+++ b/Tests/Functional/ExtractCommandTest.php
@@ -58,4 +58,38 @@ class ExtractCommandTest extends BaseCommandTestCase
         $files = FileUtils::findTranslationFiles($outputDir);
         $this->assertTrue(isset($files['messages']['en']));
     }
+    
+    public function testExtractDryRun()
+    {
+        $input = new ArgvInput(array(
+            'app/console',
+            'translation:extract',
+            'en',
+            '--dir='.($inputDir = __DIR__.'/../Translation/Extractor/Fixture/SimpleTest'),
+            '--output-dir='.($outputDir = sys_get_temp_dir().'/'.uniqid('extract')),
+            '--dry-run',
+            '--verbose'
+        ));
+
+        $expectedOutput = array(
+            'php.foo->',                                                                                                                                 
+            'php.bar-> Bar',                                                                                                                                 
+            'php.baz->',                                                                                                                                 
+            'php.foo_bar-> Foo',                                                                                                                                
+            'twig.foo->',                                                                                                                                  
+            'twig.bar-> Bar',                                                                                                                                  
+            'twig.baz->',                                                                                                                                  
+            'twig.foo_bar-> Foo',                                                                                                                                  
+            'form.foo->',                                                                                                                                  
+            'form.bar->',                                                                                                                                  
+            'controller.foo-> Foo',
+        );
+
+        $this->getApp()->run($input, $output = new Output());
+        
+        foreach($expectedOutput as $transID){
+            $this->assertContains($transID, $output->getContent());    
+        }
+
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/process": "*",
         "symfony/yaml": "*",
         "sensio/framework-extra-bundle": "*",
-        "jms/di-extra-bundle": "*"
+        "jms/di-extra-bundle": ">=1.1"
     },
     "autoload": {
         "psr-0": { "JMS\\TranslationBundle": "" }


### PR DESCRIPTION
The Output of --dry-run was confusing, because it only listet the "array_keys" which have been just numbers. In the unfortunate case, that only one message was added this resulted in an output like : "Added Messages: 0". 
Therefore are now the real number of added messages shown and with --verbose option even the message IDs with initial "desc" translation.

Comment on composer.json:
As I wanted to test my code I came across the issue that an old version of di-extra-bundle (1.0.1) was loaded. This version has no dependency on aop which caused exceptions, due to the fact that the AOPBundle is loaded in the FunctionalTest AppKernel.php
