### PR TITLE
FormExtractor extracts labels from create

### DIFF
--- a/Tests/Translation/Extractor/File/Fixture/MyFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormType.php
@@ -56,5 +56,9 @@ class MyFormType extends AbstractType
                 'translation_domain' => 'address'
             ))
         ;
+        $child = $builder->create('created', 'text', array(
+                  'label' => 'form.label.created'
+              ))
+        ;
     }
 }

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -80,6 +80,10 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
         $message->addSource(new FileSource($path, 47));
         $expected->add($message);
 
+        $message = new Message('form.label.created');
+        $message->addSource(new FileSource($path, 60));
+        $expected->add($message);
+
         $this->assertEquals($expected, $this->extract('MyFormType.php'));
     }
 

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -111,7 +111,7 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
                 return;
             }
 
-            if ('add' !== $name = strtolower($node->name)) {
+            if ('add' !== $name && 'create' !== $name) {
                 return;
             }
 


### PR DESCRIPTION
Using $builder->create() accepts the same options as ->add(), but the strings used for 'create' were never extracted
