### PR TITLE
Add $docComment checks in JMS\TranslationBundle\Translation\Extractor\File\FormExtractor::parseItem. Fixes #106

### DIFF
--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -274,7 +274,7 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
         $desc = $meaning = null;
         $docComment = $item->key->getDocComment();
         $docComment = $docComment ? $docComment : $item->value->getDocComment();
-        if ($docComment) {
+        if (isset($docComment) && $docComment) {
             foreach ($this->docParser->parse($docComment, 'file '.$this->file.' near line '.$item->value->getLine()) as $annot) {
                 if ($annot instanceof Ignore) {
                     $ignore = true;


### PR DESCRIPTION
For a value that's an instance of e.g. `PHPParser_Node_Scalar_String`, [which value holds a string](https://github.com/nikic/PHP-Parser/blob/master/lib/PHPParser/Node/Scalar/String.php#L4), there's no `getDocComment()` method. This leads to `$docComment` not being set and a fatal error as explained in #106.
