### PR TITLE
Use <pre> for displaying alternate languages

### DIFF
--- a/Resources/views/Translate/messages.html.twig
+++ b/Resources/views/Translate/messages.html.twig
@@ -22,7 +22,7 @@
                         <h6>Alternative Translations</h6>
                         {% for locale, altMessage in alternativeMessages[id] %}
                         <p>
-                            <strong>{{ locale }}:</strong> {{ altMessage.localeString }}
+                            <strong>{{ locale }}:</strong><pre> {{ altMessage.localeString }}</pre>
                         </p>
                         {% endfor %}
                     {% endif %}


### PR DESCRIPTION
I've added a _pre_ tag between the alternate translations to correctly let the user copy/paste the other language translations when there are newlines and other spacing chars
