### PR TITLE
Added Service to fix XLIFF file extension

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -61,6 +61,12 @@
             </call>
             <tag name="jms_translation.dumper" format="xliff" />
         </service>
+        <service id="jms_translation.dumper.xlf_dumper" class="%jms_translation.dumper.xliff_dumper.class%" public="false">
+            <call method="setSourceLanguage">
+                <argument>%jms_translation.source_language%</argument>
+            </call>
+            <tag name="jms_translation.dumper" format="xlf" />
+        </service>
         <service id="jms_translation.dumper.yaml_dumper" class="%jms_translation.dumper.yaml_dumper.class%" public="false">
             <tag name="jms_translation.dumper" format="yml" />
         </service>


### PR DESCRIPTION
#128

This adds another dumper service, using the `JMS\TranslationBundle\Translation\Dumper\XliffDumper` but with a format of `xlf` to match the XLIFF specification.

This would allow the output format to be set to `xlf` to generate xliff files with the `.xlf` extension.
