### PR TITLE
Fix order of JMS custom elements as per XLIFF spec

### DIFF
--- a/Tests/Translation/Dumper/xliff/structure.xml
+++ b/Tests/Translation/Dumper/xliff/structure.xml
@@ -7,10 +7,10 @@
     </header>
     <body>
       <trans-unit id="fb2d5a853a8edd799b4084a828d7d6746210534b" resname="foo.bar.baz">
-        <jms:reference-file line="1" column="2">c/foo/bar</jms:reference-file>
-        <jms:reference-file line="1" column="2">bar/baz</jms:reference-file>
         <source>foo.bar.baz</source>
         <target state="new">foo.bar.baz</target>
+        <jms:reference-file line="1" column="2">c/foo/bar</jms:reference-file>
+        <jms:reference-file line="1" column="2">bar/baz</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/Translation/Dumper/XliffDumper.php
+++ b/Translation/Dumper/XliffDumper.php
@@ -113,6 +113,7 @@ class XliffDumper implements DumperInterface
                 $target->setAttribute('state', 'new');
             }
 
+            // As per the OASIS XLIFF 1.2 non-XLIFF elements must be at the end of the <trans-unit>
             if ($sources = $message->getSources()) {
                 foreach ($sources as $source) {
                     if ($source instanceof FileSource) {


### PR DESCRIPTION
Sending a PR on behalf of @ChMat for issue #39

As per OASIS XLIFF 1.2 specification document (http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#trans-unit), this is the order to follow in trans-unit elements:
Contents:
One <source> element, followed by 
Zero or one <seg-source> element, followed by 
Zero or one <target> element, followed by
Zero, one or more <context-group>, <count-group>, <prop-group>, <note>, <alt-trans> elements, in any order, followed by
Zero, one or more non-XLIFF elements.
All child elements of <trans-unit> pertain to their sibling <source> element.
While for backward compatibility reasons no order is enforced for the elements before the non-XLIFF elements, the recommended order is the one in which they are listed here.
