### PR TITLE
Handle variants where attr is not an array but a function pointer.

### DIFF
--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -114,7 +114,7 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
                     foreach ($item->value->items as $sitem) {
                         $this->parseItem($sitem, $domain);
                     }
-                } elseif ('attr' === $item->key->value ) {
+                } elseif ('attr' === $item->key->value && is_array($item->value->items) ) {
                     foreach ($item->value->items as $sitem) {
                         if ('placeholder' == $sitem->key->value){
                             $this->parseItem($sitem, $domain);


### PR DESCRIPTION
Example code that chrashes without this fix: 

``` php
    $resolver->setDefaults(array(                                                 
            'error_bubbling' => false,                                                
            'invalid_message' => "Invalid resource selected",                         
            'type' => false,                                                          

            'allowed_resource_types' => false,                                        
            'required' => false,                                                      
            'attr' => function(Options $options) use ($router) {                      
                return array(                                                         
                'placeholder' => "Search for a movie",                                
                'class' => 'resource_selector auto_complete',                         
                "data-url-all" => ($options['allowed_resource_types'] !== false) ?    
                        $router->generate('admin_resource_query_type', array('type' => $options['allowed_resource_types'])) :
                         $router->generate('admin_resource_query', array())           
                );                                                                    

            }                                                                         
            )                                                                         
        );     

```
