### PR TITLE
Ints should be translatable in choice lists.

### DIFF
--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -207,7 +207,7 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
         // check if the value is explicitly set to false => e.g. for FormField that should be rendered without label
         $ignore = $ignore || $item->value->value == false;
 
-        if (!$item->value instanceof \PHPParser_Node_Scalar_String) {
+        if (!$item->value instanceof \PHPParser_Node_Scalar_String && !$item->value instanceof \PHPParser_Node_Scalar_LNumber) {
             if ($ignore) {
                 return;
             }


### PR DESCRIPTION
Somtimes the translationstrings are ints.
