### PR TITLE
Sort translation locales

### DIFF
--- a/Controller/TranslateController.php
+++ b/Controller/TranslateController.php
@@ -74,6 +74,9 @@ class TranslateController
         }
 
         $locales = array_keys($files[$domain]);
+        
+        natsort($locales);
+        
         if ((!$locale = $this->request->query->get('locale')) || !isset($files[$domain][$locale])) {
             $locale = reset($locales);
         }


### PR DESCRIPTION
Right now the locales in the drop down are not sorted alphabetical. If you have a lot of different locales this can be very confusing. This PR fixes that.
