### PR TITLE
Skip keys with the @Ignore annotation in the FormExtractor

### DIFF
--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -184,10 +184,10 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
 
     private function parseItem($item, $domain = null)
     {
-        // get doc comment
         $ignore = false;
         $desc = $meaning = $docComment = null;
 
+        // get doc comment
         if ($item->key) {
             $docComment = $item->key->getDocComment();
         }


### PR DESCRIPTION
This small change allows you to skip keys from FormTypes by adding the @Ignore annotation.

Either put the annotation before the array key or array value:

``` php
$builder->add('foo', 'bar', array('label' => /** @Ignore */ 'Foo'));
```

or 

``` php
$builder->add('foo', 'bar', array(/** @Ignore */ 'label' => 'Foo'));
```

Works for FormTypes as well as Sonata Admin extensions.

It would be possible to ignore entire arrays (useful for `choices` for example) but this would mean duplicating code and therefore wasn’t included in the PR.

See #20
