### PR TITLE
Method addBuilder to permit to inject aditionnal builders at runtime

### DIFF
--- a/Translation/ConfigFactory.php
+++ b/Translation/ConfigFactory.php
@@ -47,4 +47,9 @@ class ConfigFactory
     {
         return $this->getBuilder($name)->setLocale($locale)->getConfig();
     }
+
+    public function addBuilder($name, $builder)
+    {
+        $this->builders[$name] = $builder;
+    }
 }


### PR DESCRIPTION
Basically, I want to register some additional ConfigBuilders in a CompilerPass, which is impossible without an "addBuilder" method.
