### PR TITLE
Moved alert message to previous TD

### DIFF
--- a/Resources/views/Translate/index.html.twig
+++ b/Resources/views/Translate/index.html.twig
@@ -23,10 +23,10 @@
                             $(self).parent().closest('td').prev('td').children('.alert-message').remove();
                         },
                         error: function() {
-                            $(self).parent().closest('td').prev('td').append('<br><span class="alert-message label error">Could not be saved.</span>');
+                            $(self).parent().closest('td').prev('td').append('<span class="alert-message label error">Could not be saved.</span>');
                         },
                         success: function() {
-                            $(self).parent().closest('td').prev('td').append('<br><span class="alert-message label success">Translation was saved.</span>');
+                            $(self).parent().closest('td').prev('td').append('<span class="alert-message label success">Translation was saved.</span>');
                         },
                         complete: function() {
                             var parent = $(self).parent();

--- a/Resources/views/Translate/messages.html.twig
+++ b/Resources/views/Translate/messages.html.twig
@@ -11,7 +11,7 @@
             <tr>
                 <td>
                     <a class="jms-translation-anchor" id="{{ id }}" />
-                    <abbr title="{{ id }}">{{ id|truncate(20) }}</abbr>
+                    <p><abbr title="{{ id }}">{{ id|truncate(20) }}</abbr></p>
                 </td>
                 <td>
                     <textarea data-id="{{ id }}" class="span6"{% if isWriteable is sameas(false) %} readonly="readonly"{% endif %}>{{ message.localeString }}</textarea></td>


### PR DESCRIPTION
I think the current way of showing the success and error messages is annoying, when you wanna change more then one translation. The alert-message was prepended to the text area, what was causing the column height going up. 
I moved the alert message to the previous TD, so you can Tab between the text areas without the columns are changing height. 
