### PR TITLE
Default domain settings

### DIFF
--- a/Command/ExtractTranslationCommand.php
+++ b/Command/ExtractTranslationCommand.php
@@ -56,6 +56,7 @@ class ExtractTranslationCommand extends ContainerAwareCommand
             ->addOption('default-output-format', null, InputOption::VALUE_REQUIRED, 'The default output format (defaults to xliff).')
             ->addOption('keep', null, InputOption::VALUE_NONE, 'Define if the updater service should keep the old translation (defaults to false).')
             ->addOption('external-translations-dir', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED , 'Load external translation ressources')
+            ->addOption('default-domain', null, InputOption::VALUE_REQUIRED , 'Domain that is going to be used when no domain is detected in translation - Default: messages')
         ;
     }
 
@@ -194,6 +195,10 @@ class ExtractTranslationCommand extends ContainerAwareCommand
 
         if ($loadResource = $input->getOption('external-translations-dir')) {
             $builder->setLoadResources($loadResource);
+        }
+
+        if ($defaultDomain = $input->getOption('default-domain')) {
+            $builder->setDefaultDomain($defaultDomain);
         }
     }
 }

--- a/Translation/Config.php
+++ b/Translation/Config.php
@@ -40,12 +40,13 @@ final class Config
     private $excludedDirs;
     private $excludedNames;
     private $enabledExtractors;
+    private $defaultDomain;
 
     private $keepOldMessages;
     private $loadResources;
 
 
-    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources)
+    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources, $defaultDomain = 'messages')
     {
         if (empty($translationsDir)) {
             throw new InvalidArgumentException('The directory where translations are must be set.');
@@ -85,6 +86,7 @@ final class Config
         $this->enabledExtractors = $enabledExtractors;
         $this->keepOldMessages = $keepOldMessages;
         $this->loadResources = $loadResources;
+        $this->defaultDomain = $defaultDomain;
     }
 
     /**
@@ -207,5 +209,13 @@ final class Config
     public function getLoadResources()
     {
         return $this->loadResources;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultDomain()
+    {
+        return $this->defaultDomain;
     }
 }

--- a/Translation/ConfigBuilder.php
+++ b/Translation/ConfigBuilder.php
@@ -32,6 +32,7 @@ final class ConfigBuilder
     private $enabledExtractors = array();
     private $keepOldTranslations = false;
     private $loadResources = array();
+    private $defaultDomain = 'messages';
 
     /**
      * @static
@@ -52,6 +53,7 @@ final class ConfigBuilder
         $builder->setExcludedNames($config->getExcludedNames());
         $builder->setEnabledExtractors($config->getEnabledExtractors());
         $builder->setLoadResources($config->getLoadResources());
+        $builder->setDefaultDomain($config->getDefaultDomain());
 
         return $builder;
     }
@@ -188,6 +190,13 @@ final class ConfigBuilder
         return $this;
     }
 
+    public function setDefaultDomain($domain)
+    {
+        $this->defaultDomain = $domain;
+
+        return $this;
+    }
+
     public function getConfig()
     {
         return new Config(
@@ -202,7 +211,8 @@ final class ConfigBuilder
             $this->excludedNames,
             $this->enabledExtractors,
             $this->keepOldTranslations,
-            $this->loadResources
+            $this->loadResources,
+            $this->defaultDomain
         );
     }
 

--- a/Translation/Extractor/DomainAwareInterface.php
+++ b/Translation/Extractor/DomainAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace JMS\TranslationBundle\Translation\Extractor;
+
+interface DomainAwareInterface
+{
+    /**
+     * @param string $domain
+     */
+    public function setDomain($domain);
+}

--- a/Translation/Extractor/File/AuthenticationMessagesExtractor.php
+++ b/Translation/Extractor/File/AuthenticationMessagesExtractor.php
@@ -25,12 +25,13 @@ use JMS\TranslationBundle\Annotation\Meaning;
 use JMS\TranslationBundle\Annotation\Desc;
 use JMS\TranslationBundle\Annotation\Ignore;
 use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\Extractor\DomainAwareInterface;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use Doctrine\Common\Annotations\DocParser;
 use JMS\TranslationBundle\Logger\LoggerAwareInterface;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
-class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisitorInterface, \PHPParser_NodeVisitor
+class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisitorInterface, \PHPParser_NodeVisitor, DomainAwareInterface
 {
     private $domain = 'authentication';
     private $traverser;

--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -25,6 +25,7 @@ use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Annotation\Meaning;
 use JMS\TranslationBundle\Annotation\Desc;
 use JMS\TranslationBundle\Annotation\Ignore;
+use JMS\TranslationBundle\Translation\Extractor\DomainAwareInterface;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Logger\LoggerAwareInterface;
@@ -37,7 +38,7 @@ use Symfony\Component\HttpKernel\Log\LoggerInterface;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterface, \PHPParser_NodeVisitor
+class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterface, \PHPParser_NodeVisitor, DomainAwareInterface
 {
     private $traverser;
     private $catalogue;
@@ -45,6 +46,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
     private $docParser;
     private $logger;
     private $previousNode;
+    private $defaultDomain = 'messages';
 
     public function __construct(DocParser $docParser)
     {
@@ -59,6 +61,11 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+    }
+
+    public function setDomain($domain)
+    {
+        $this->defaultDomain = $domain;
     }
 
     public function enterNode(\PHPParser_Node $node)
@@ -122,7 +129,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
 
             $domain = $node->args[$index]->value->value;
         } else {
-            $domain = 'messages';
+            $domain = $this->defaultDomain;
         }
 
         $message = new Message($id, $domain);

--- a/Translation/Extractor/File/ValidationExtractor.php
+++ b/Translation/Extractor/File/ValidationExtractor.php
@@ -19,6 +19,7 @@
 namespace JMS\TranslationBundle\Translation\Extractor\File;
 
 use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\Extractor\DomainAwareInterface;
 use Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface;
 use Symfony\Component\Validator\MetadataFactoryInterface;
 use JMS\TranslationBundle\Model\MessageCatalogue;
@@ -29,13 +30,14 @@ use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class ValidationExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
+class ValidationExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor, DomainAwareInterface
 {
     private $metadataFactory;
     private $traverser;
     private $file;
     private $catalogue;
     private $namespace = '';
+    private $defaultDomain = 'validators';
 
     public function __construct($metadataFactory)
     {
@@ -46,6 +48,11 @@ class ValidationExtractor implements FileVisitorInterface, \PHPParser_NodeVisito
 
         $this->traverser = new \PHPParser_NodeTraverser();
         $this->traverser->addVisitor($this);
+    }
+
+    public function setDomain($domain)
+    {
+        $this->defaultDomain = $domain;
     }
 
     public function enterNode(\PHPParser_Node $node)
@@ -108,7 +115,7 @@ class ValidationExtractor implements FileVisitorInterface, \PHPParser_NodeVisito
                 if (strtolower(substr($propName, -1 * strlen('Message'))) === 'message') {
                     // If it is different from the default value
                     if ($defaultValues[$propName] !== $constraint->{$propName}) {
-                        $message = new Message($constraint->{$propName}, 'validators');
+                        $message = new Message($constraint->{$propName}, $this->defaultDomain);
                         $this->catalogue->add($message);
                     }
                 }

--- a/Translation/Extractor/FileExtractor.php
+++ b/Translation/Extractor/FileExtractor.php
@@ -35,7 +35,7 @@ use Symfony\Component\Finder\Finder;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class FileExtractor implements ExtractorInterface, LoggerAwareInterface
+class FileExtractor implements ExtractorInterface, LoggerAwareInterface, DomainAwareInterface
 {
     private $twig;
     private $visitors;
@@ -47,6 +47,7 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
     private $excludedNames = array();
     private $excludedDirs = array();
     private $logger;
+    private $defaultDomain = 'messages';
 
     public function __construct(\Twig_Environment $twig, LoggerInterface $logger, array $visitors)
     {
@@ -108,6 +109,18 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
     {
         $this->pattern = $pattern;
     }
+
+    public function setDomain($domain)
+    {
+        $this->defaultDomain = $domain;
+
+        foreach ($this->visitors as $visitor) {
+            if ($visitor instanceof DomainAwareInterface) {
+                $visitor->setDomain($this->defaultDomain);
+            }
+        }
+    }
+
 
     public function extract()
     {

--- a/Translation/Updater.php
+++ b/Translation/Updater.php
@@ -229,6 +229,7 @@ class Updater
         $this->extractor->setExcludedDirs($config->getExcludedDirs());
         $this->extractor->setExcludedNames($config->getExcludedNames());
         $this->extractor->setEnabledExtractors($config->getEnabledExtractors());
+        $this->extractor->setDomain($config->getDefaultDomain());
 
         $this->logger->info("Extracting translation keys");
         $this->scannedCatalogue = $this->extractor->extract();


### PR DESCRIPTION
Idea behind this pull request is to be able to define different default domain.

We are creating different domains for different parts of the system to translate these separately. Now we can define default-domain which should be used for all translations which are not using different domain explicitly.

Does it make sense to add defaultDomain to all extractors? Originally the idea was to extract Catalogue of messages and just change domain from messages to specific domain, but then if some translations would be explicitly messages it would not work correctly.

I can add unit and functional tests right after when you confirm that something like this make sense.