### PR TITLE
Allow users to override the translation template rendered

### DIFF
--- a/Controller/TranslateController.php
+++ b/Controller/TranslateController.php
@@ -48,6 +48,9 @@ class TranslateController
     /** @DI\Inject("%jms_translation.source_language%") */
     private $sourceLanguage;
 
+    /** @DI\Inject("%jms_translation.template%") */
+    private $template;
+
     /**
      * @Route("/", name="jms_translation_index", options = {"i18n" = false})
      * @Template
@@ -118,7 +121,7 @@ class TranslateController
             $existingMessages[$id] = $message;
         }
 
-        return array(
+        return $this->container->get('templating')->renderResponse($this->template,array(
             'selectedConfig' => $config,
             'configs' => $configs,
             'selectedDomain' => $domain,
@@ -132,6 +135,6 @@ class TranslateController
             'isWriteable' => is_writeable($files[$domain][$locale][1]),
             'file' => (string) $files[$domain][$locale][1],
             'sourceLanguage' => $this->sourceLanguage,
-        );
+        ));
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration implements ConfigurationInterface
             ->root('jms_translation')
                 ->fixXmlConfig('config')
                 ->children()
+                    ->scalarNode('template')->end()
                     ->arrayNode('locales')
                         ->prototype('scalar')->end()
                     ->end()

--- a/DependencyInjection/JMSTranslationExtension.php
+++ b/DependencyInjection/JMSTranslationExtension.php
@@ -96,6 +96,9 @@ class JMSTranslationExtension extends Extension
             $requests[$name] = $def;
         }
 
+        if(isset($config['template']))
+            $container->setParameter('jms_translation.template',$config['template']);
+
         $container
             ->getDefinition('jms_translation.config_factory')
             ->addArgument($requests)

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -30,6 +30,7 @@
         
         <parameter key="jms_translation.updater.class">JMS\TranslationBundle\Translation\Updater</parameter>
         <parameter key="jms_translation.config_factory.class">JMS\TranslationBundle\Translation\ConfigFactory</parameter>
+        <parameter key="jms_translation.template">JMSTranslationBundle:Translate:index.html.twig</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
Some users may want to integrate the translation controller with
their own bundle for theming purposes. This allows them to set what
template the controller uses.

If this is accepted you should ignore my other PR that removes the container from the controller.
