### PR TITLE
removed truncate filter from messages in translation UI

### DIFF
--- a/Resources/views/Translate/messages.html.twig
+++ b/Resources/views/Translate/messages.html.twig
@@ -11,7 +11,7 @@
             <tr>
                 <td>
                     <a class="jms-translation-anchor" id="{{ id }}" />
-                    <p><abbr title="{{ id }}">{{ id|truncate(20) }}</abbr></p>
+                    <p><abbr title="{{ id }}">{{ id }}</abbr></p>
                 </td>
                 <td>
                     <textarea data-id="{{ id }}" class="span6"{% if isWriteable is sameas(false) %} readonly="readonly"{% endif %}>{{ message.localeString }}</textarea></td>


### PR DESCRIPTION
I found having a truncated ID very unusable (I cannot search the ID in the browser if the translation is already set for example)