### PR TITLE
Extract to template

### DIFF
--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -4,7 +4,7 @@ Usage
 Creating Translation Messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 While not strictly necessary, this bundle strongly advocates the usage of
-abstract keys such as "form.label.firstname" as translation messages. Many of 
+abstract keys such as "form.label.firstname" as translation messages. Many of
 the features of this bundle were designed to facilitate this.
 
 Abstract keys are used for two main reasons:
@@ -12,13 +12,13 @@ Abstract keys are used for two main reasons:
 #. Translation messages are mostly written by developers, and thus their
    first draft of the message might not be perfect from a copywriters point
    of view, or changes might be necessitated later for other reasons. These
-   changes would then result in changes for all supported languages instead 
+   changes would then result in changes for all supported languages instead
    of only for the source language, and some translations might actually be
    lost in the process.
 
-#. Some words in English (or whatever your source language is) are spelled 
-   differently in other languages depending on their meaning. Let's take the 
-   English word "Archive" as an example. This can be a noun ("The Archive"), 
+#. Some words in English (or whatever your source language is) are spelled
+   differently in other languages depending on their meaning. Let's take the
+   English word "Archive" as an example. This can be a noun ("The Archive"),
    and also a verb ("to archive"). In German, these are two different words
    "Archiv" for the noun, and "Archivieren" for the verb. If you were using
    the source message as id, you could not use the word "Archiv" with different
@@ -26,8 +26,8 @@ Abstract keys are used for two main reasons:
    "Archiv", or "Archivieren", but not both.
 
 Whereas abstract keys do not suffer from these limitations, they come with some
-of their own. For example, sometimes it is hard for the translator to know what 
-s/he is supposed to translate. Let's take a look at the following example where 
+of their own. For example, sometimes it is hard for the translator to know what
+s/he is supposed to translate. Let's take a look at the following example where
 we use the source message as key:
 
 .. code-block :: jinja
@@ -35,7 +35,7 @@ we use the source message as key:
     {# index.html.twig #}
     {{ "{0} There is no apples|{1} There is one apple|]1,Inf] There are %count% apples"|transchoice(count) }}
 
-If we translate this to use an abstract key instead, we would get something like 
+If we translate this to use an abstract key instead, we would get something like
 the following:
 
 .. code-block :: jinja
@@ -44,8 +44,8 @@ the following:
     {{ "text.apples_remaining"|transchoice(count) }}
 
 If a translator now sees this abstract key, s/he does not really know what the
-expected translation should look like. Fortunately, there is a solution for 
-this. We simply allow the developer to convey more context to the translator 
+expected translation should look like. Fortunately, there is a solution for
+this. We simply allow the developer to convey more context to the translator
 via the ``desc`` filter:
 
 .. code-block :: jinja
@@ -64,7 +64,7 @@ be used as the default translation.
     The ``desc`` filter is removed when your Twig template is compiled, and does
     not affect the runtime performance of your template.
 
-Of course, an equivalent to the ``desc`` filter is also available for 
+Of course, an equivalent to the ``desc`` filter is also available for
 translations in PHP code, the ``@Desc`` annotation:
 
 .. code-block :: php
@@ -75,17 +75,17 @@ translations in PHP code, the ``@Desc`` annotation:
     /** @Desc("{0} There is no apples|{1} There is one apple|]1,Inf] There are %count% apples") */
     $this->translator->transChoice('text_apples_remaining', $count)
 
-You can place the doc comment anywhere in the method call chain or directly 
+You can place the doc comment anywhere in the method call chain or directly
 before the key.
 
 Extracting Translation Messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This bundle automatically supports extracting messages from the following 
+This bundle automatically supports extracting messages from the following
 sources:
 
 - Twig: ``trans``, and ``transchoice`` filters as well as ``trans``,
   and ``transchoice`` blocks
-- PHP: 
+- PHP:
 
   - all calls to the ``trans``, or ``transChoice`` method
   - all classes implementing the ``TranslationContainerInterface``
@@ -102,7 +102,7 @@ you can implement an ``ExtractorInterface`` service, and tag it with ``jms_trans
 
 As an example, you can take a look at the JMSI18nRoutingBundle_ which implements an `extractor service`_
 for routes, and the corresponding `service definition`_.
-Due to the global nature of these extractors, they are not enabled by default, but you need to 
+Due to the global nature of these extractors, they are not enabled by default, but you need to
 enabled each of them explicitly. You can do that by passing the ``--enable-extractor=fooAlias``
 command line option, or enable it in the configuration (see below).
 
@@ -137,15 +137,18 @@ bundle:
 .. code-block :: bash
 
     php app/console translation:extract de --bundle=MyFooBundle
-    
+
 .. tip ::
 
     This bundle supports the following formats: csv, ini, php, qt, xliff, and yml
-    
-    Note however, that the best integration exists with the XLIFF format. This is simply 
-    due to the fact that the other formats are not so extensible, and do not allow for 
-    some of the more advanced features like tracking where a translation is used, whether 
+
+    Note however, that the best integration exists with the XLIFF format. This is simply
+    due to the fact that the other formats are not so extensible, and do not allow for
+    some of the more advanced features like tracking where a translation is used, whether
     it is new, etc.
 
-    
-    
+
+Template locale
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+There is a special locale named template. When such locale is used for dumping into an xliff format, suggested translation is not saved.
+You can use such xliff file as Template in online translation tools like Pootle.

--- a/Tests/Translation/Dumper/XliffDumperTest.php
+++ b/Tests/Translation/Dumper/XliffDumperTest.php
@@ -84,6 +84,17 @@ EOF;
         $this->assertEquals($expected, $dumper->dump($catalogue, 'messages'));
     }
 
+    public function testTemplateDump()
+    {
+        $catalogue = new MessageCatalogue();
+        $catalogue->setLocale('template');
+
+        $message = new Message('template');
+        $catalogue->add($message);
+
+        $this->assertEquals($this->getOutput('template'), $this->getDumper()->dump($catalogue, 'messages', true));
+    }
+
     protected function getDumper()
     {
         $dumper = new XliffDumper();

--- a/Tests/Translation/Dumper/XliffDumperTest.php
+++ b/Tests/Translation/Dumper/XliffDumperTest.php
@@ -54,6 +54,36 @@ EOF;
         $this->assertEquals($expected, $dumper->dump($catalogue, 'messages'));
     }
 
+    public function testPreserveWhitespaceOutput()
+    {
+        $dumper = $this->getDumper();
+
+        $catalogue = new MessageCatalogue();
+        $catalogue->add(Message::create('foo')->setLocaleString("multi-line\ntranslation")->setDesc("Multi-line\ndescription\nwith spaces at the end   "));
+        $expected = <<<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" resname="foo">
+        <source xml:space="preserve">Multi-line
+description
+with spaces at the end   </source>
+        <target xml:space="preserve" state="new">multi-line
+translation</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+
+EOF;
+        $this->assertEquals($expected, $dumper->dump($catalogue, 'messages'));
+    }
+
     protected function getDumper()
     {
         $dumper = new XliffDumper();

--- a/Tests/Translation/Dumper/xliff/template.xml
+++ b/Tests/Translation/Dumper/xliff/template.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="template" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="3226ecbe650213a49cd03ae67140750e4f340083" resname="template">
+        <source>template</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Tests/Translation/FileWriterTest.php
+++ b/Tests/Translation/FileWriterTest.php
@@ -47,7 +47,7 @@ class FileWriterTest extends \PHPUnit_Framework_TestCase
         $catalogue->add(new Message('foo.bar'));
 
         $path = tempnam(sys_get_temp_dir(), 'filewriter');
-        $writer->write($catalogue, 'messages', $path, 'test');
+        $writer->write($catalogue, 'messages', $path, 'test', false);
         @unlink($path);
     }
 }

--- a/Translation/Dumper/ArrayStructureDumper.php
+++ b/Translation/Dumper/ArrayStructureDumper.php
@@ -30,7 +30,7 @@ abstract class ArrayStructureDumper implements DumperInterface
         $this->prettyPrint = (Boolean) $bool;
     }
 
-    public function dump(MessageCatalogue $catalogue, $domain = 'messages')
+    public function dump(MessageCatalogue $catalogue, $domain = 'messages', $template = false)
     {
         $structure = $catalogue->getDomain($domain)->all();
 

--- a/Translation/Dumper/DumperInterface.php
+++ b/Translation/Dumper/DumperInterface.php
@@ -35,7 +35,8 @@ interface DumperInterface
      *
      * @param MessageCatalogue $catalogue
      * @param string $domain
+     * @param boolean $template
      * @return string
      */
-    function dump(MessageCatalogue $catalogue, $domain = 'messages');
+    function dump(MessageCatalogue $catalogue, $domain = 'messages', $template = false);
 }

--- a/Translation/Dumper/SymfonyDumperAdapter.php
+++ b/Translation/Dumper/SymfonyDumperAdapter.php
@@ -46,7 +46,7 @@ class SymfonyDumperAdapter implements DumperInterface
         $this->format = $format;
     }
 
-    public function dump(MessageCatalogue $catalogue, $domain = 'messages')
+    public function dump(MessageCatalogue $catalogue, $domain = 'messages', $template = false)
     {
         $symfonyCatalogue = new SymfonyCatalogue($catalogue->getLocale());
 

--- a/Translation/Dumper/XliffDumper.php
+++ b/Translation/Dumper/XliffDumper.php
@@ -55,7 +55,7 @@ class XliffDumper implements DumperInterface
      * @param \JMS\TranslationBundle\Model\MessageCatalogue $domain
      * @return string
      */
-    public function dump(MessageCatalogue $catalogue, $domain = 'messages')
+    public function dump(MessageCatalogue $catalogue, $domain = 'messages', $template = false)
     {
         $doc = new \DOMDocument('1.0', 'utf-8');
         $doc->formatOutput = true;
@@ -107,18 +107,24 @@ class XliffDumper implements DumperInterface
             }
 
             $unit->appendChild($target = $doc->createElement('target'));
-            if (preg_match('/[<>&]/', $message->getLocaleString())) {
-                $target->appendChild($doc->createCDATASection($message->getLocaleString()));
-            } else {
-                $target->appendChild($doc->createTextNode($message->getLocaleString()));
+            if (!$template) {
+                if (preg_match('/[<>&]/', $message->getLocaleString())) {
+                    $target->appendChild($doc->createCDATASection($message->getLocaleString()));
+                } else {
+                    $target->appendChild($doc->createTextNode($message->getLocaleString()));
 
-                if (preg_match("/\r\n|\n|\r|\t/", $message->getLocaleString())) {
+                    if (preg_match("/\r\n|\n|\r|\t/", $message->getLocaleString())) {
+                        $target->setAttribute('xml:space', 'preserve');
+                    }
+                }
+
+                if ($message->isNew()) {
+                    $target->setAttribute('state', 'new');
+                }
+            } else {
+                if (preg_match("/\r\n|\n|\r|\t/", $message->getSourceString())) {
                     $target->setAttribute('xml:space', 'preserve');
                 }
-            }
-
-            if ($message->isNew()) {
-                $target->setAttribute('state', 'new');
             }
 
             // As per the OASIS XLIFF 1.2 non-XLIFF elements must be at the end of the <trans-unit>

--- a/Translation/Dumper/XliffDumper.php
+++ b/Translation/Dumper/XliffDumper.php
@@ -100,6 +100,10 @@ class XliffDumper implements DumperInterface
                 $source->appendChild($doc->createCDATASection($message->getSourceString()));
             } else {
                 $source->appendChild($doc->createTextNode($message->getSourceString()));
+
+                if (preg_match("/\r\n|\n|\r|\t/", $message->getSourceString())) {
+                    $source->setAttribute('xml:space', 'preserve');
+                }
             }
 
             $unit->appendChild($target = $doc->createElement('target'));
@@ -107,6 +111,10 @@ class XliffDumper implements DumperInterface
                 $target->appendChild($doc->createCDATASection($message->getLocaleString()));
             } else {
                 $target->appendChild($doc->createTextNode($message->getLocaleString()));
+
+                if (preg_match("/\r\n|\n|\r|\t/", $message->getLocaleString())) {
+                    $target->setAttribute('xml:space', 'preserve');
+                }
             }
 
             if ($message->isNew()) {

--- a/Translation/FileWriter.php
+++ b/Translation/FileWriter.php
@@ -46,9 +46,10 @@ class FileWriter
      * @param \JMS\TranslationBundle\Model\MessageCatalogue $domain
      * @param $filePath
      * @param $format
+     * @param $template
      * @throws \JMS\TranslationBundle\Exception\InvalidArgumentException
      */
-    public function write(MessageCatalogue $catalogue, $domain, $filePath, $format)
+    public function write(MessageCatalogue $catalogue, $domain, $filePath, $format, $template)
     {
         if (!isset($this->dumpers[$format])) {
             throw new InvalidArgumentException(sprintf('The format "%s" is not supported.', $format));
@@ -59,6 +60,6 @@ class FileWriter
             return strcmp($a->getId(), $b->getId());
         });
 
-        file_put_contents($filePath, $this->dumpers[$format]->dump($catalogue, $domain));
+        file_put_contents($filePath, $this->dumpers[$format]->dump($catalogue, $domain, $template));
     }
 }

--- a/Translation/Updater.php
+++ b/Translation/Updater.php
@@ -148,9 +148,13 @@ class Updater
                 }
             }
 
-            $outputFile = $this->config->getTranslationsDir().'/'.$name.'.'.$this->config->getLocale().'.'.$format;
+            $outputFile = $this->config->getTranslationsDir().'/'.$name.'.';
+            if ($template = 'template' !== strtolower($this->config->getLocale())) {
+                $outputFile .= $this->config->getLocale().'.';
+            }
+            $outputFile .= $format;
             $this->logger->info(sprintf('Writing translation file "%s".', $outputFile));
-            $this->writer->write($this->scannedCatalogue, $name, $outputFile, $format);
+            $this->writer->write($this->scannedCatalogue, $name, $outputFile, $format, !$template);
         }
     }
 


### PR DESCRIPTION
There is a special locale named template. When such locale is used for dumping into an xliff format, suggested translation is not saved.

You can use such xliff file as Template in online translation tools like Pootle.