### PR TITLE
Allow to extend the DefaultPhpFileExtractor watched methods

### DIFF
--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -75,6 +75,16 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
     private $previousNode;
 
     /**
+     * Methods and "domain" parameter offset to extract from PHP code
+     *
+     * @var array method => position of the "domain" parameter
+     */
+    protected $methodsToExtractFrom = array(
+        'trans' => 2,
+        'transchoice' => 3,
+    );
+
+    /**
      * DefaultPhpFileExtractor constructor.
      * @param DocParser $docParser
      */
@@ -101,7 +111,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
     {
         if (!$node instanceof Node\Expr\MethodCall
             || !is_string($node->name)
-            || ('trans' !== strtolower($node->name) && 'transchoice' !== strtolower($node->name))) {
+            || !in_array(strtolower($node->name), array_map('strtolower', array_keys($this->methodsToExtractFrom)))) {
             $this->previousNode = $node;
             return;
         }
@@ -140,7 +150,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
 
         $id = $node->args[0]->value->value;
 
-        $index = 'trans' === strtolower($node->name) ? 2 : 3;
+        $index = $this->methodsToExtractFrom[strtolower($node->name)];
         if (isset($node->args[$index])) {
             if (!$node->args[$index]->value instanceof String_) {
                 if ($ignore) {


### PR DESCRIPTION
The methods extracted in `DefaultPhpFileExtractor` are hard-coded `trans` and `transchoice`, this make it very hard to add a needed extraction method (in fact we are forced to copy the full class to alter it behavior just a bit).

My proposal is to expose the list of methods to extract in a `protected` property,
allowing anyone to extend `DefaultPhpFileExtractor` and just define some more methods to extract with their "domain" parameter offset (can be "-1" if there is none).

The use case for me is that I have shortcuts in my Controllers to create error and success flash messages. I call a `addErrorFlash("translation_key");` and my BaseController do the translator `trans()` call for me, leaving my Controllers clean and without noise. But I then need the translation extractor to watch for `adderrorflash` too.

Thx a lot,
Damien