### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "minimum-stability": "dev",
     "require": {
         "symfony/framework-bundle": "~2.1",
-        "nikic/php-parser": "0.9.4",
+        "nikic/php-parser": "v0.9.4",
         "symfony/console": "*"
     },
     "conflict": {


### PR DESCRIPTION
Fix problem 
    - jms/translation-bundle 1.1.x-dev requires nikic/php-parser 0.9.4 -> no matching package found.