### PR TITLE
Read translation files in all subdirectories

### DIFF
--- a/Translation/Updater.php
+++ b/Translation/Updater.php
@@ -148,7 +148,7 @@ class Updater
                 }
             }
 
-            $outputFile = $this->config->getTranslationsDir().'/'.$name.'.'.$this->config->getLocale().'.'.$format;
+            $outputFile = FileUtils::computeTranslationFile($this->config->getTranslationsDir(), $name, $this->config->getLocale(), $format);
             $this->logger->info(sprintf('Writing translation file "%s".', $outputFile));
             $this->writer->write($this->scannedCatalogue, $name, $outputFile, $format);
         }

--- a/Util/FileUtils.php
+++ b/Util/FileUtils.php
@@ -41,7 +41,7 @@ abstract class FileUtils
     public static function findTranslationFiles($directory)
     {
         $files = array();
-        foreach (Finder::create()->in($directory)->depth('< 1')->files() as $file) {
+        foreach (Finder::create()->in($directory)->files() as $file) {
             if (!preg_match('/^([^\.]+)\.([^\.]+)\.([^\.]+)$/', basename($file), $match)) {
                 continue;
             }
@@ -55,6 +55,24 @@ abstract class FileUtils
         uksort($files, 'strcasecmp');
         
         return $files;
+    }
+
+    /**
+     * Search for the file with the same name, in all subdirectories, and return its full file name. If not found, we assume it will be put directly in the directory
+     *
+     * @param $directory
+     * @param $domainName
+     * @param $locale
+     * @param $fileFormat
+     * @return string
+     */
+    public static function computeTranslationFile($directory, $domainName, $locale, $fileFormat) {
+        $fileName = "$domainName.$locale.$fileFormat";
+
+        foreach (Finder::create()->in($directory)->files()->name($fileName) as $file) {
+            return $file;
+        }
+        return "$directory/$fileName";
     }
 
     private final function __construct() { }


### PR DESCRIPTION
Read translation files in all subdirectories, like Symfony does (tested with 2.3)
When writing the file, we will search for a file with the same name and over write it, instead of just searching in the target directory root.
