### PR TITLE
Mark all translations as translated when the target locale matches the source language

### DIFF
--- a/DependencyInjection/JMSTranslationExtension.php
+++ b/DependencyInjection/JMSTranslationExtension.php
@@ -42,6 +42,10 @@ class JMSTranslationExtension extends Extension
             $def->addMethodCall('setTranslationsDir', array($extractConfig['output_dir']));
             $def->addMethodCall('setScanDirs', array($extractConfig['dirs']));
 
+            if ($config['source_language']) {
+                $def->addMethodCall('setSourceLanguage', array($config['source_language']));
+            }
+
             if (isset($extractConfig['ignored_domains'])) {
                 $ignored = array();
                 foreach ($extractConfig['ignored_domains'] as $domain) {

--- a/Translation/Config.php
+++ b/Translation/Config.php
@@ -43,13 +43,16 @@ final class Config
 
     private $keepOldMessages;
     private $loadResources;
+    private $sourceLanguage;
 
 
-    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources)
+    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources, $sourceLanguage = null)
     {
         if (empty($translationsDir)) {
             throw new InvalidArgumentException('The directory where translations are must be set.');
         }
+
+        $this->sourceLanguage = $sourceLanguage;
 
         if (!is_dir($translationsDir)) {
             if (false === @mkdir($translationsDir, 0777, true)) {
@@ -207,5 +210,13 @@ final class Config
     public function getLoadResources()
     {
         return $this->loadResources;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSourceLanguage()
+    {
+        return $this->sourceLanguage;
     }
 }

--- a/Translation/ConfigBuilder.php
+++ b/Translation/ConfigBuilder.php
@@ -32,6 +32,7 @@ final class ConfigBuilder
     private $enabledExtractors = array();
     private $keepOldTranslations = false;
     private $loadResources = array();
+    private $sourceLanguage = 'en';
 
     /**
      * @static
@@ -52,6 +53,7 @@ final class ConfigBuilder
         $builder->setExcludedNames($config->getExcludedNames());
         $builder->setEnabledExtractors($config->getEnabledExtractors());
         $builder->setLoadResources($config->getLoadResources());
+        $builder->setSourceLanguage($config->getSourceLanguage());
 
         return $builder;
     }
@@ -187,6 +189,12 @@ final class ConfigBuilder
 
         return $this;
     }
+    
+    public function setSourceLanguage($sourceLanguage)
+    {
+        $this->sourceLanguage = $sourceLanguage;
+        return $this;
+    }
 
     public function getConfig()
     {
@@ -202,7 +210,8 @@ final class ConfigBuilder
             $this->excludedNames,
             $this->enabledExtractors,
             $this->keepOldTranslations,
-            $this->loadResources
+            $this->loadResources,
+            $this->sourceLanguage
         );
     }
 

--- a/Translation/Updater.php
+++ b/Translation/Updater.php
@@ -234,6 +234,16 @@ class Updater
         $this->scannedCatalogue = $this->extractor->extract();
         $this->scannedCatalogue->setLocale($config->getLocale());
 
+        // mark all translations as translated when the current locale matches the source language
+        if ($this->config->getLocale() === $this->config->getSourceLanguage()) {
+            foreach ($this->scannedCatalogue->getDomains() as $domainCatalogue) {
+                foreach ($domainCatalogue->all() as $message) {
+                    $message->setNew(false);
+                    $message->setLocaleString($message->getId());
+                }
+            }
+        }
+
         // merge existing messages into scanned messages
         foreach ($this->scannedCatalogue->getDomains() as $domainCatalogue) {
             foreach ($domainCatalogue->all() as $message) {


### PR DESCRIPTION
Hi, 
this PR will solve https://github.com/schmittjoh/JMSTranslationBundle/issues/197 issue.

When the source language matches the target locale, then all translations should be considered as translated.

If you are using some kind of placeholders instead of message strings (eg: `label.button.text`) then, your source language should be `null`...
