### PR TITLE
Added placeholder option

### DIFF
--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -101,12 +101,23 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
                     }
                     continue;
                 }
+                
+                if ('placeholder' === $item->key->value && $item->value instanceof \PHPParser_Node_Expr_ConstFetch
+                    && $item->value->name instanceof \PHPParser_Node_Name && 'false' === $item->value->name->parts[0]) {
+                    continue;
+                }
+                if ('placeholder' === $item->key->value && $item->value instanceof \PHPParser_Node_Expr_Array) {
+                    foreach ($item->value->items as $sitem) {
+                        $this->parseItem($sitem, $domain);
+                    }
+                    continue;
+                }
 
                 if ('choices' === $item->key->value && !$item->value instanceof \PHPParser_Node_Expr_Array) {
                     continue;
                 }
 
-                if ('label' !== $item->key->value && 'empty_value' !== $item->key->value && 'choices' !== $item->key->value && 'invalid_message' !== $item->key->value && 'attr' !== $item->key->value ) {
+                if ('label' !== $item->key->value && 'empty_value' !== $item->key->value && 'placeholder' !== $item->key->value && 'choices' !== $item->key->value && 'invalid_message' !== $item->key->value && 'attr' !== $item->key->value ) {
                     continue;
                 }
 


### PR DESCRIPTION
In Symfony 2.6 (and later 3.0) is empty_value in choice form field replaced with placeholder.

https://github.com/symfony/symfony/blob/master/UPGRADE-2.6.md