### PR TITLE
correct unit test 

### DIFF
--- a/Tests/Functional/TranslationTest.php
+++ b/Tests/Functional/TranslationTest.php
@@ -11,6 +11,6 @@ class TranslationTest extends BaseTestCase
         $response = $client->getResponse();
 
         $this->assertEquals(200, $response->getStatusCode(), substr($response, 0, 2000));
-        $this->assertEquals("There are 5 apples\n\nThere are 5 apples", $response->getContent());
+        $this->assertEquals("text.apples_remaining_does_not_exist\n\nThere are 5 apples", $response->getContent());
     }
 }


### PR DESCRIPTION
correct unit test : 
"text.apples_remaining_does_not_exist" have no translation in messages.en.php : 
<?php

return array(
    'text.apples_remaining' => '{0} There is no apple|{1} There is one apple|]1,Inf] There are %count% apples',
);