### PR TITLE
Set Loggers on NodeVisitors at construct time

### DIFF
--- a/Translation/Extractor/FileExtractor.php
+++ b/Translation/Extractor/FileExtractor.php
@@ -97,8 +97,8 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
     public function __construct(\Twig_Environment $twig, LoggerInterface $logger, array $visitors)
     {
         $this->twig = $twig;
-        $this->logger = $logger;
         $this->visitors = $visitors;
+        $this->setLogger($logger);
         $lexer = new Lexer();
         if (class_exists('PhpParser\ParserFactory')) {
             $factory = new ParserFactory();


### PR DESCRIPTION
Currently, no logger is set on node visitors at construct time. This enforces users of the library to do something like

```php
$extractor = new FileExtractor($twig, $logger, $visitors);
$extractor->setLogger($logger);
```