### PR TITLE
nikic/php-parser version update to 1.4.1 or 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "minimum-stability": "stable",
     "require": {
         "symfony/framework-bundle": "~2.1|~3.0",
-        "nikic/php-parser": "~1.4.1",
+        "nikic/php-parser": "~1.4.1|~2.0.0",
         "symfony/console": "*"
     },
     "conflict": {


### PR DESCRIPTION
nikic/php-parser version update to 1.4.1 or 2.0.0