### PR TITLE
Added option to keep initial translated messages

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -38,6 +38,7 @@
             <argument type="service" id="jms_translation.extractor_manager" />
             <argument type="service" id="logger" />
             <argument type="service" id="jms_translation.file_writer" />
+            <argument type="service" id="translator.default" />
         </service>
         
         <service id="jms_translation.config_factory" class="%jms_translation.config_factory.class%" />

--- a/Tests/Functional/ExtractCommandTest.php
+++ b/Tests/Functional/ExtractCommandTest.php
@@ -38,6 +38,7 @@ class ExtractCommandTest extends BaseCommandTestCase
         $expectedOutput =
             'Extracting Translations for locale en'."\n"
            .'Keep old translations: No'."\n"
+           .'Keep old translations messages: No'."\n"
            .'Output-Path: '.$outputDir."\n"
            .'Directories: '.$inputDir."\n"
            .'Excluded Directories: Tests'."\n"

--- a/Translation/Config.php
+++ b/Translation/Config.php
@@ -42,10 +42,11 @@ final class Config
     private $enabledExtractors;
 
     private $keepOldMessages;
+    private $keepOldTranslationsMessages;
     private $loadResources;
 
 
-    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources)
+    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, $keepOldTranslationsMessages, array $loadResources)
     {
         if (empty($translationsDir)) {
             throw new InvalidArgumentException('The directory where translations are must be set.');
@@ -84,6 +85,7 @@ final class Config
         $this->excludedNames = $excludedNames;
         $this->enabledExtractors = $enabledExtractors;
         $this->keepOldMessages = $keepOldMessages;
+        $this->keepOldTranslationsMessages = $keepOldTranslationsMessages;
         $this->loadResources = $loadResources;
     }
 
@@ -200,6 +202,15 @@ final class Config
     {
         return $this->keepOldMessages;
     }
+
+    /**
+     * @return Boolean
+     */
+    public function isKeepOldTranslationsMessages()
+    {
+        return $this->keepOldTranslationsMessages;
+    }
+
 
     /**
      * @return array

--- a/Translation/ConfigBuilder.php
+++ b/Translation/ConfigBuilder.php
@@ -31,6 +31,7 @@ final class ConfigBuilder
     private $excludedNames = array('*Test.php', '*TestCase.php');
     private $enabledExtractors = array();
     private $keepOldTranslations = false;
+    private $keepOldTranslationsMessages = false;
     private $loadResources = array();
 
     /**
@@ -188,6 +189,14 @@ final class ConfigBuilder
         return $this;
     }
 
+
+    public function setKeepOldTranslationsMessages($value)
+    {
+        $this->keepOldTranslationsMessages = $value;
+
+        return $this;
+    }
+
     public function getConfig()
     {
         return new Config(
@@ -202,6 +211,7 @@ final class ConfigBuilder
             $this->excludedNames,
             $this->enabledExtractors,
             $this->keepOldTranslations,
+            $this->keepOldTranslationsMessages,
             $this->loadResources
         );
     }


### PR DESCRIPTION
I've done [this](https://github.com/schmittjoh/JMSTranslationBundle/issues/277) myself.

Option `--keeptm ` while running the command will allow users to use it on already translated projects without losing their already done translations. Their translations will not be replaced by the keys, but by the translated text.  All of the translations are not set as new.
