### PR TITLE
Fix issue 281. Replace symfony class parameter by full class name

### DIFF
--- a/DependencyInjection/Compiler/IntegrationPass.php
+++ b/DependencyInjection/Compiler/IntegrationPass.php
@@ -30,7 +30,7 @@ class IntegrationPass implements CompilerPassInterface
         }
 
         $def = $container->getDefinition('translation.loader.xliff');
-        if ('%translation.loader.xliff.class%' !== $def->getClass()) {
+        if ('Symfony\Component\Translation\Loader\XliffFileLoader' !== $def->getClass()) {
             // user needs to manually integrate as desired
             return;
         }


### PR DESCRIPTION
Broken after this symfony commit: https://github.com/symfony/symfony/commit/8835d1af45c7adef264a2f20fed69c712d0e188f#diff-ace3ed7f9c8dd7ded3aa562e3c25fa92