### PR TITLE
Symfony 3.0 compat

### DIFF
--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -40,9 +40,6 @@ class ApiController
     /** @DI\Inject("jms_translation.config_factory") */
     private $configFactory;
 
-    /** @DI\Inject */
-    private $request;
-
     /** @DI\Inject("jms_translation.updater") */
     private $updater;
 
@@ -72,7 +69,7 @@ class ApiController
 
         $this->updater->updateTranslation(
             $file, $format, $domain, $locale, $id,
-            $this->request->request->get('message')
+	    $request->request->get('message')
         );
 
         return new Response();

--- a/Controller/TranslateController.php
+++ b/Controller/TranslateController.php
@@ -23,8 +23,8 @@ use JMS\TranslationBundle\Util\FileUtils;
 use JMS\DiExtraBundle\Annotation as DI;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\MessageCatalogue;
 
 /**
  * Translate Controller.
@@ -68,9 +68,9 @@ class TranslateController
         }
 
         $locales = array_keys($files[$domain]);
-        
+
         natsort($locales);
-        
+
         if ((!$locale = $request->query->get('locale')) || !isset($files[$domain][$locale])) {
             $locale = reset($locales);
         }

--- a/DependencyInjection/Compiler/IntegrationPass.php
+++ b/DependencyInjection/Compiler/IntegrationPass.php
@@ -30,7 +30,7 @@ class IntegrationPass implements CompilerPassInterface
         }
 
         $def = $container->getDefinition('translation.loader.xliff');
-        if ('%translation.loader.xliff.class%' !== $def->getClass()) {
+	if ('%translation.loader.xliff.class%' !== $def->getClass() && 'Symfony\Component\Translation\Loader\XliffFileLoader' !== $def->getClass()) {
             // user needs to manually integrate as desired
             return;
         }


### PR DESCRIPTION
- Also consider FQCN when overriding translation.loader.xliff in compiler (Replaces #295)
- Use injected request in controllers