### PR TITLE
Only support official supported symfony versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
     - travis_retry composer self-update
 
 install:
-    - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
+    - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
     - composer update ${COMPOSER_FLAGS} --prefer-source --no-interaction
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,19 +28,9 @@ matrix:
 
     include:
         - php: 5.3
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_VERSION=2.1.* COVERAGE=true TEST_COMMAND="phpunit --coverage-text --coverage-clover=build/coverage.xml"
-        - php: 5.6
-          env: SYMFONY_VERSION=2.1.*
-        - php: 5.6
-          env: SYMFONY_VERSION=2.2.*
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_VERSION=2.3.* COVERAGE=true TEST_COMMAND="phpunit --coverage-text --coverage-clover=build/coverage.xml"
         - php: 5.6
           env: SYMFONY_VERSION=2.3.*
-        - php: 5.6
-          env: SYMFONY_VERSION=2.4.*
-        - php: 5.6
-          env: SYMFONY_VERSION=2.5.*
-        - php: 5.6
-          env: SYMFONY_VERSION=2.6.*
         - php: 5.6
           env: SYMFONY_VERSION=2.7.*
         - php: 5.6

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,13 @@
+# Changelog
+
+
+
+### 1.2 to 1.3
+
+* New maintainers: @gnat42, @gouaille and @nyholm.
+* Updated Jquery from 1.6.1 to 1.12.0
+* Dropping support for Symfony 2.1, 2.2, 2.4, 2.5 and 2.6.
+
+### 1.1 to 1.2
+
+* Lots of minor changes and improvements from June 2013.

--- a/Twig/TranslationExtension.php
+++ b/Twig/TranslationExtension.php
@@ -106,9 +106,13 @@ class TranslationExtension extends \Twig_Extension
     private function transchoiceWithDefaultLegacy($message, $defaultMessage, $count, array $arguments, $domain, $locale)
     {
         try {
-            return $this->translator->transChoice($message, $count, array_merge(array('%count%' => $count), $arguments), $domain, $locale);
-        } catch (\InvalidArgumentException $e) {
-            return $this->translator->transChoice($defaultMessage, $count, array_merge(array('%count%' => $count), $arguments), $domain, $locale);
-        }
+            $translatedMessage = $this->translator->transChoice($message, $count, array_merge(array('%count%' => $count), $arguments), $domain, $locale);
+
+            if ($translatedMessage !== $message) {
+                return $translatedMessage;
+            }
+        } catch (\InvalidArgumentException $e) {}
+        
+        return $this->translator->transChoice($defaultMessage, $count, array_merge(array('%count%' => $count), $arguments), $domain, $locale);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,18 +14,18 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^5.3.3|^7.0",
-        "symfony/framework-bundle": "^2.1|^3.0",
+        "symfony/framework-bundle": "^2.3|^3.0",
         "nikic/php-parser": "~1.4.1",
-        "symfony/console": "^2.1|^3.0"
+        "symfony/console": "^2.3|^3.0"
     },
     "conflict": {
         "twig/twig": "<1.12"
     },
     "require-dev": {
         "twig/twig": "^1.12",
-        "symfony/symfony": "^2.1|^3.0",
+        "symfony/symfony": "^2.3|^3.0",
         "symfony/expression-language": "~2.6|~3.0",
-        "sensio/framework-extra-bundle": "^2.1|^3.0",
+        "sensio/framework-extra-bundle": "^2.3|^3.0",
         "jms/di-extra-bundle": "^1.1"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #305 
| License       | MIT


## Description
This will drop support for Symfony 2.1, 2.2, 2.4, 2.5 and 2.6.

## Todos
- [x] Changelog
