### PR TITLE
remove unused injected container

### DIFF
--- a/Controller/TranslateController.php
+++ b/Controller/TranslateController.php
@@ -42,9 +42,6 @@ class TranslateController
     /** @DI\Inject("jms_translation.loader_manager") */
     private $loader;
 
-    /** @DI\Inject("service_container") */
-    private $container;
-
     /** @DI\Inject("%jms_translation.source_language%") */
     private $sourceLanguage;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT


## Description
The container variable is unused. We completely remove it and save it from being injected for no reason.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
