### PR TITLE
getting rid of the twig text extension

### DIFF
--- a/Resources/doc/webinterface.rst
+++ b/Resources/doc/webinterface.rst
@@ -15,26 +15,12 @@ the routes by adding the following to ``app/config/routing_dev.yml`` (note
 that you need to have the SensioFrameworkExtraBundle_ installed)::
 
     JMSTranslationBundle_ui:
-        resource: @JMSTranslationBundle/Controller/
+        resource: "@JMSTranslationBundle/Controller/"
         type:     annotation
         prefix:   /_trans
 
 This bundle also requires the JMSDiExtraBundle_ for annotation-based
 dependency injection for controllers.
-
-This bundle also makes use of the Twig ``truncate`` filter which you find
-in the `Twig extensions`_ repository. You can install it, by adding the
-following to your ``app/config/config.yml``::
-
-    services:
-        twig.text_extension:
-            class: Twig_Extensions_Extension_Text
-            tags:
-                - name: twig.extension
-
-.. _SensioFrameworkExtraBundle: https://github.com/sensio/SensioFrameworkExtraBundle
-.. _JMSDiExtraBundle: https://github.com/schmittjoh/JMSDiExtraBundle
-.. _Twig extensions: http://github.com/fabpot/Twig-extensions
 
 Usage
 -----

--- a/Resources/views/Translate/messages.html.twig
+++ b/Resources/views/Translate/messages.html.twig
@@ -11,7 +11,7 @@
             <tr>
                 <td>
                     <a class="jms-translation-anchor" id="{{ id }}" />
-                    <p><abbr title="{{ id }}">{{ id|truncate(20) }}</abbr></p>
+                    <p><abbr title="{{ id }}">{{ id|slice(0, 25) }}{% if id|length > 25 %}...{% endif %}</abbr></p>
                 </td>
                 <td>
                     <textarea data-id="{{ id }}" class="span6"{% if isWriteable is same as(false) %} readonly="readonly"{% endif %}>{{ message.localeString }}</textarea></td>
@@ -20,7 +20,7 @@
                         <h6>Meaning</h6>
                         <p>{{ message.meaning }}</p>
                     {% endif %}
-                
+
                     {% if alternativeMessages[id] is defined %}
                         <h6>Alternative Translations</h6>
                         {% for locale, altMessage in alternativeMessages[id] %}
@@ -29,7 +29,7 @@
                         </p>
                         {% endfor %}
                     {% endif %}
-                    
+
                     {% if message.sources|length > 0 %}
                         <h6>Sources</h6>
                         <ul>
@@ -39,7 +39,7 @@
                         </ul>
                     {% endif %}
 
-                    {% if message.desc is not empty 
+                    {% if message.desc is not empty
                             and message.localeString != message.desc
                             and id != message.desc
                             and (alternativeMessages[id][sourceLanguage] is not defined


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #299
| License       | MIT


## Description
The twig extension Text was used with the filter truncate only one time. Using slice filter solves the problem.
