### PR TITLE
update php-parser to either 1.4.1 or 2.x

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 
 ### 1.2.1 to next release
 
+* Support nikic/php-parser 1.4.x and 2.0.x
 
 ### 1.2.0 to 1.2.1
 

--- a/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
@@ -23,6 +23,8 @@ use JMS\TranslationBundle\Model\MessageCatalogue;
 use Doctrine\Common\Annotations\DocParser;
 
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use PhpParser\Lexer;
+use PhpParser\ParserFactory;
 
 abstract class BasePhpFileExtractorTest extends \PHPUnit_Framework_TestCase
 {
@@ -37,8 +39,14 @@ abstract class BasePhpFileExtractorTest extends \PHPUnit_Framework_TestCase
             $extractor = $this->getDefaultExtractor();
         }
 
-        $lexer = new \PHPParser_Lexer();
-        $parser = new \PHPParser_Parser($lexer);
+        $lexer = new Lexer();
+        if(class_exists('PhpParser\ParserFactory')) {
+            $factory = new ParserFactory();
+            $parser = $factory->create(ParserFactory::PREFER_PHP7,$lexer);
+        } else {
+            $parser = new \PHPParser_Parser($lexer);
+        }
+
         $ast = $parser->parse(file_get_contents($file));
 
         $catalogue = new MessageCatalogue();

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -25,6 +25,8 @@ use JMS\TranslationBundle\Translation\Extractor\File\FormExtractor;
 use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
+use PhpParser\Lexer;
+use PhpParser\ParserFactory;
 
 class FormExtractorTest extends \PHPUnit_Framework_TestCase
 {
@@ -244,8 +246,14 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
         }
         $file = new \SplFileInfo($file);
 
-        $lexer = new \PHPParser_Lexer();
-        $parser = new \PHPParser_Parser($lexer);
+        $lexer = new Lexer();
+        if(class_exists('PhpParser\ParserFactory')) {
+            $factory = new ParserFactory();
+            $parser = $factory->create(ParserFactory::PREFER_PHP7,$lexer);
+        } else {
+            $parser = new \PHPParser_Parser($lexer);
+        }
+
         $ast = $parser->parse(file_get_contents($file));
 
         $catalogue = new MessageCatalogue();

--- a/Tests/Translation/Extractor/File/TranslationContainerExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TranslationContainerExtractorTest.php
@@ -23,6 +23,8 @@ use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\Extractor\File\TranslationContainerExtractor;
 use JMS\TranslationBundle\Model\MessageCatalogue;
+use PhpParser\Lexer;
+use PhpParser\ParserFactory;
 
 class TranslationContainerExtractorTest extends \PHPUnit_Framework_TestCase
 {
@@ -53,8 +55,14 @@ class TranslationContainerExtractorTest extends \PHPUnit_Framework_TestCase
             $extractor = new TranslationContainerExtractor();
         }
 
-        $lexer = new \PHPParser_Lexer();
-        $parser = new \PHPParser_Parser($lexer);
+        $lexer = new Lexer();
+        if(class_exists('PhpParser\ParserFactory')) {
+            $factory = new ParserFactory();
+            $parser = $factory->create(ParserFactory::PREFER_PHP7,$lexer);
+        } else {
+            $parser = new \PHPParser_Parser($lexer);
+        }
+
         $ast = $parser->parse(file_get_contents($file));
 
         $catalogue = new MessageCatalogue();

--- a/Tests/Translation/Extractor/File/ValidationExtractorTest.php
+++ b/Tests/Translation/Extractor/File/ValidationExtractorTest.php
@@ -21,6 +21,8 @@ namespace JMS\TranslationBundle\Tests\Translation\Extractor\File;
 use JMS\TranslationBundle\Exception\RuntimeException;
 use Doctrine\Common\Annotations\AnnotationReader;
 
+use PhpParser\Lexer;
+use PhpParser\ParserFactory;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 
 use Symfony\Component\Validator\Mapping\ClassMetadataFactory;
@@ -64,8 +66,14 @@ class ValidationExtractorTest extends \PHPUnit_Framework_TestCase
             $extractor = new ValidationExtractor($factory);
         }
 
-        $lexer = new \PHPParser_Lexer();
-        $parser = new \PHPParser_Parser($lexer);
+        $lexer = new Lexer();
+        if(class_exists('PhpParser\ParserFactory')) {
+            $factory = new ParserFactory();
+            $parser = $factory->create(ParserFactory::PREFER_PHP7,$lexer);
+        } else {
+            $parser = new \PHPParser_Parser($lexer);
+        }
+
         $ast = $parser->parse(file_get_contents($file));
 
         $catalogue = new MessageCatalogue();

--- a/Translation/Extractor/File/AuthenticationMessagesExtractor.php
+++ b/Translation/Extractor/File/AuthenticationMessagesExtractor.php
@@ -28,9 +28,12 @@ use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use Doctrine\Common\Annotations\DocParser;
 use JMS\TranslationBundle\Logger\LoggerAwareInterface;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use Psr\Log\LoggerInterface;
 
-class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisitorInterface, \PHPParser_NodeVisitor
+class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisitorInterface, NodeVisitor
 {
     private $domain = 'authentication';
     private $traverser;
@@ -45,7 +48,7 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
     public function __construct(DocParser $parser)
     {
         $this->docParser = $parser;
-        $this->traverser = new \PHPParser_NodeTraverser();
+        $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor($this);
     }
 
@@ -59,15 +62,15 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
         $this->domain = $domain;
     }
 
-    public function enterNode(\PHPParser_Node $node)
+    public function enterNode(Node $node)
     {
-        if ($node instanceof \PHPParser_Node_Stmt_Namespace) {
+        if ($node instanceof Node\Stmt\Namespace_) {
             $this->namespace = implode('\\', $node->name->parts);
 
             return;
         }
 
-        if ($node instanceof \PHPParser_Node_Stmt_Class) {
+        if ($node instanceof Node\Stmt\Class_) {
             $name = '' === $this->namespace ? $node->name : $this->namespace.'\\'.$node->name;
 
             if (!class_exists($name)) {
@@ -92,7 +95,7 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
             return;
         }
 
-        if ($node instanceof \PHPParser_Node_Stmt_ClassMethod) {
+        if ($node instanceof Node\Stmt\ClassMethod) {
             if ('getmessagekey' === strtolower($node->name)) {
                 $this->inGetMessageKey = true;
             }
@@ -104,7 +107,7 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
             return;
         }
 
-        if (!$node instanceof \PHPParser_Node_Stmt_Return) {
+        if (!$node instanceof Node\Stmt\Return_) {
             return;
         }
 
@@ -122,7 +125,7 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
             }
         }
 
-        if (!$node->expr instanceof \PHPParser_Node_Scalar_String) {
+        if (!$node->expr instanceof Node\Scalar\String_) {
             if ($ignore) {
                 return;
             }
@@ -154,15 +157,15 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
         $this->traverser->traverse($ast);
     }
 
-    public function leaveNode(\PHPParser_Node $node)
+    public function leaveNode(Node $node)
     {
-        if ($node instanceof \PHPParser_Node_Stmt_Class) {
+        if ($node instanceof Node\Stmt\Class_) {
             $this->inAuthException = false;
 
             return;
         }
 
-        if ($node instanceof \PHPParser_Node_Stmt_ClassMethod) {
+        if ($node instanceof Node\Stmt\ClassMethod) {
             $this->inGetMessageKey = false;
 
             return;

--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -28,6 +28,11 @@ use JMS\TranslationBundle\Annotation\Ignore;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Logger\LoggerAwareInterface;
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+use PhpParser\Node\Scalar\String_;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -37,7 +42,7 @@ use Psr\Log\LoggerInterface;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterface, \PHPParser_NodeVisitor
+class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterface, NodeVisitor
 {
     private $traverser;
     private $catalogue;
@@ -49,7 +54,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
     public function __construct(DocParser $docParser)
     {
         $this->docParser = $docParser;
-        $this->traverser = new \PHPParser_NodeTraverser();
+        $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor($this);
     }
 
@@ -61,10 +66,10 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
         $this->logger = $logger;
     }
 
-    public function enterNode(\PHPParser_Node $node)
+    public function enterNode(Node $node)
     {
 
-        if (!$node instanceof \PHPParser_Node_Expr_MethodCall
+        if (!$node instanceof Node\Expr\MethodCall
             || !is_string($node->name)
             || ('trans' !== strtolower($node->name) && 'transchoice' !== strtolower($node->name))) {
 
@@ -75,7 +80,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
         $ignore = false;
         $desc = $meaning = null;
         if (null !== $docComment = $this->getDocCommentForNode($node)) {
-            if ($docComment instanceof \PhpParser\Comment\Doc) {
+            if ($docComment instanceof Doc) {
                 $docComment = $docComment->getText();
             }
             foreach ($this->docParser->parse($docComment, 'file '.$this->file.' near line '.$node->getLine()) as $annot) {
@@ -89,7 +94,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
             }
         }
 
-        if (!$node->args[0]->value instanceof \PHPParser_Node_Scalar_String) {
+        if (!$node->args[0]->value instanceof String_) {
             if ($ignore) {
                 return;
             }
@@ -108,7 +113,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
 
         $index = 'trans' === strtolower($node->name) ? 2 : 3;
         if (isset($node->args[$index])) {
-            if (!$node->args[$index]->value instanceof \PHPParser_Node_Scalar_String) {
+            if (!$node->args[$index]->value instanceof String_) {
                 if ($ignore) {
                     return;
                 }
@@ -144,12 +149,12 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
     }
 
     public function beforeTraverse(array $nodes) { }
-    public function leaveNode(\PHPParser_Node $node) { }
+    public function leaveNode(Node $node) { }
     public function afterTraverse(array $nodes) { }
     public function visitFile(\SplFileInfo $file, MessageCatalogue $catalogue) { }
     public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast) { }
 
-    private function getDocCommentForNode(\PHPParser_Node $node)
+    private function getDocCommentForNode(Node $node)
     {
         // check if there is a doc comment for the ID argument
         // ->trans(/** @Desc("FOO") */ 'my.id')

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -28,9 +28,13 @@ use Doctrine\Common\Annotations\DocParser;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use JMS\TranslationBundle\Logger\LoggerAwareInterface;
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use Psr\Log\LoggerInterface;
 
-class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
+class FormExtractor implements FileVisitorInterface, NodeVisitor
 {
     private $docParser;
     private $traverser;
@@ -44,19 +48,19 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
     {
         $this->docParser = $docParser;
 
-        $this->traverser = new \PHPParser_NodeTraverser();
+        $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor($this);
     }
 
 
-    public function enterNode(\PHPParser_Node $node)
+    public function enterNode(Node $node)
     {
-        if ($node instanceof \PHPParser_Node_Stmt_Class) {
+        if ($node instanceof Node\Stmt\Class_) {
             $this->defaultDomain = null;
             $this->defaultDomainMessages = array();
         }
 
-        if ($node instanceof \PHPParser_Node_Expr_MethodCall) {
+        if ($node instanceof Node\Expr\MethodCall) {
             if (!is_string($node->name)) {
                 return;
             }
@@ -68,16 +72,16 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
             }
         }
 
-         if ($node instanceof \PHPParser_Node_Expr_Array) {
+         if ($node instanceof Node\Expr\Array_) {
             // first check if a translation_domain is set for this field
             $domain = null;
             foreach ($node->items as $item) {
-                if (!$item->key instanceof \PHPParser_Node_Scalar_String) {
+                if (!$item->key instanceof Node\Scalar\String_) {
                     continue;
                 }
 
                 if ('translation_domain' === $item->key->value) {
-                    if (!$item->value instanceof \PHPParser_Node_Scalar_String) {
+                    if (!$item->value instanceof Node\Scalar\String_) {
                         continue;
                     }
 
@@ -87,22 +91,22 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
 
             // look for options containing a message
             foreach ($node->items as $item) {
-                if (!$item->key instanceof \PHPParser_Node_Scalar_String) {
+                if (!$item->key instanceof Node\Scalar\String_) {
                     continue;
                 }
 
-                if ('empty_value' === $item->key->value && $item->value instanceof \PHPParser_Node_Expr_ConstFetch
-                    && $item->value->name instanceof \PHPParser_Node_Name && 'false' === $item->value->name->parts[0]) {
+                if ('empty_value' === $item->key->value && $item->value instanceof Node\Expr\ConstFetch
+                    && $item->value->name instanceof Node\Name && 'false' === $item->value->name->parts[0]) {
                 	continue;
                 }
-                if ('empty_value' === $item->key->value && $item->value instanceof \PHPParser_Node_Expr_Array) {
+                if ('empty_value' === $item->key->value && $item->value instanceof Node\Expr\Array_) {
                     foreach ($item->value->items as $sitem) {
                         $this->parseItem($sitem, $domain);
                     }
                     continue;
                 }
 
-                if ('choices' === $item->key->value && !$item->value instanceof \PHPParser_Node_Expr_Array) {
+                if ('choices' === $item->key->value && !$item->value instanceof Node\Expr\Array_) {
                     continue;
                 }
 
@@ -132,7 +136,7 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
         }
     }
 
-    private function parseDefaultsCall($name, \PHPParser_Node $node)
+    private function parseDefaultsCall($name, Node $node)
     {
         static $returningMethods = array(
             'setdefaults' => true, 'replacedefaults' => true, 'setoptional' => true, 'setrequired' => true,
@@ -141,7 +145,7 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
         );
 
         $var = $node->var;
-        while ($var instanceof \PHPParser_Node_Expr_MethodCall) {
+        while ($var instanceof Node\Expr\MethodCall) {
             if (!isset($returningMethods[strtolower($var->name)])) {
                 return;
             }
@@ -150,7 +154,7 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
         }
 
 
-        if (!$var instanceof \PHPParser_Node_Expr_Variable) {
+        if (!$var instanceof Node\Expr\Variable) {
             return;
         }
 
@@ -160,19 +164,19 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
         }
 
         // ignore everything except an array
-        if (!$node->args[0]->value instanceof \PHPParser_Node_Expr_Array) {
+        if (!$node->args[0]->value instanceof Node\Expr\Array_) {
             return;
         }
 
         // check if a translation_domain is set as a default option
         $domain = null;
         foreach ($node->args[0]->value->items as $item) {
-            if (!$item->key instanceof \PHPParser_Node_Scalar_String) {
+            if (!$item->key instanceof Node\Scalar\String_) {
                 continue;
             }
 
             if ('translation_domain' === $item->key->value) {
-                if (!$item->value instanceof \PHPParser_Node_Scalar_String) {
+                if (!$item->value instanceof Node\Scalar\String_) {
                     continue;
                 }
 
@@ -199,7 +203,7 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
         $docComment = is_object($docComment) ? $docComment->getText() : null;
 
         if ($docComment) {
-            if ($docComment instanceof \PhpParser\Comment\Doc) {
+            if ($docComment instanceof Doc) {
                 $docComment = $docComment->getText();
             }
             foreach ($this->docParser->parse($docComment, 'file '.$this->file.' near line '.$item->value->getLine()) as $annot) {
@@ -214,9 +218,9 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
         }
 
         // check if the value is explicitly set to false => e.g. for FormField that should be rendered without label
-        $ignore = $ignore || !$item->value instanceof PhpParser\Node\Scalar\String_ || $item->value->value == false;
+        $ignore = $ignore || !$item->value instanceof Node\Scalar\String_ || $item->value->value == false;
 
-        if (!$item->value instanceof \PHPParser_Node_Scalar_String && !$item->value instanceof \PHPParser_Node_Scalar_LNumber) {
+        if (!$item->value instanceof Node\Scalar\String_ && !$item->value instanceof Node\Scalar\LNumber) {
             if ($ignore) {
                 return;
             }
@@ -280,7 +284,7 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
         }
     }
 
-    public function leaveNode(\PHPParser_Node $node) { }
+    public function leaveNode(Node $node) { }
 
     public function beforeTraverse(array $nodes) { }
     public function afterTraverse(array $nodes) { }

--- a/Translation/Extractor/File/TranslationContainerExtractor.php
+++ b/Translation/Extractor/File/TranslationContainerExtractor.php
@@ -23,6 +23,9 @@ use JMS\TranslationBundle\Model\Message;
 
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 
 /**
  * Extracts translations from designated translation containers.
@@ -32,7 +35,7 @@ use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class TranslationContainerExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
+class TranslationContainerExtractor implements FileVisitorInterface, NodeVisitor
 {
     private $traverser;
     private $file;
@@ -42,26 +45,26 @@ class TranslationContainerExtractor implements FileVisitorInterface, \PHPParser_
 
     public function __construct()
     {
-        $this->traverser = new \PHPParser_NodeTraverser();
+        $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor($this);
     }
 
-    public function enterNode(\PHPParser_Node $node)
+    public function enterNode(Node $node)
     {
-        if ($node instanceof \PHPParser_Node_Stmt_Namespace) {
+        if ($node instanceof Node\Stmt\Namespace_) {
             $this->namespace = implode('\\', $node->name->parts);
             $this->useStatements = array();
 
             return;
         }
 
-        if ($node instanceof \PHPParser_Node_Stmt_UseUse) {
+        if ($node instanceof Node\Stmt\UseUse) {
             $this->useStatements[$node->alias] = implode('\\', $node->name->parts);
 
             return;
         }
 
-        if (!$node instanceof \PHPParser_Node_Stmt_Class) {
+        if (!$node instanceof Node\Stmt\Class_) {
             return;
         }
 
@@ -104,7 +107,7 @@ class TranslationContainerExtractor implements FileVisitorInterface, \PHPParser_
     }
 
     public function beforeTraverse(array $nodes) { }
-    public function leaveNode(\PHPParser_Node $node) { }
+    public function leaveNode(Node $node) { }
     public function afterTraverse(array $nodes) { }
     public function visitFile(\SplFileInfo $file, MessageCatalogue $catalogue) { }
     public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast) { }

--- a/Translation/Extractor/File/ValidationExtractor.php
+++ b/Translation/Extractor/File/ValidationExtractor.php
@@ -18,6 +18,9 @@
 
 namespace JMS\TranslationBundle\Translation\Extractor\File;
 
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\MetadataFactoryInterface as LegacyMetadataFactoryInterface;
@@ -30,7 +33,7 @@ use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class ValidationExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
+class ValidationExtractor implements FileVisitorInterface, NodeVisitor
 {
     private $metadataFactory;
     private $traverser;
@@ -49,19 +52,19 @@ class ValidationExtractor implements FileVisitorInterface, \PHPParser_NodeVisito
         }
         $this->metadataFactory = $metadataFactory;
 
-        $this->traverser = new \PHPParser_NodeTraverser();
+        $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor($this);
     }
 
-    public function enterNode(\PHPParser_Node $node)
+    public function enterNode(Node $node)
     {
-        if ($node instanceof \PHPParser_Node_Stmt_Namespace) {
+        if ($node instanceof Node\Stmt\Namespace_) {
             $this->namespace = implode('\\', $node->name->parts);
 
             return;
         }
 
-        if (!$node instanceof \PHPParser_Node_Stmt_Class) {
+        if (!$node instanceof Node\Stmt\Class_) {
             return;
         }
 
@@ -93,7 +96,7 @@ class ValidationExtractor implements FileVisitorInterface, \PHPParser_NodeVisito
     }
 
     public function beforeTraverse(array $nodes) { }
-    public function leaveNode(\PHPParser_Node $node) { }
+    public function leaveNode(Node $node) { }
     public function afterTraverse(array $nodes) { }
     public function visitFile(\SplFileInfo $file, MessageCatalogue $catalogue) { }
     public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast) { }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^5.3.3|^7.0",
         "symfony/framework-bundle": "^2.3|^3.0",
-        "nikic/php-parser": "~1.4.1",
+        "nikic/php-parser": "^1.4|^2.0",
         "symfony/console": "^2.3|^3.0"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #290 
| License       | MIT


## Description
This updates composer.json to allow for php-parser 1.4.1 or 2.0. 2.0 requires php 5.4 and 1.4.1 can be used on php 5.3. We need to maintain both versions until we no longer support a symfony version running on php 5.3.

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Changelog
