### PR TITLE
Fix logger interface calls

### DIFF
--- a/Translation/Extractor/File/AuthenticationMessagesExtractor.php
+++ b/Translation/Extractor/File/AuthenticationMessagesExtractor.php
@@ -40,6 +40,10 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
     private $docParser;
     private $inAuthException = false;
     private $inGetMessageKey = false;
+
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
 
     public function __construct(DocParser $parser)
@@ -129,7 +133,7 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
 
             $message = sprintf('Could not extract id from return value, expected scalar string but got %s (in %s on line %d).', get_class($node->expr), $this->file, $node->expr->getLine());
             if ($this->logger) {
-                $this->logger->err($message);
+                $this->logger->error($message);
 
                 return;
             }

--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -43,6 +43,10 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
     private $catalogue;
     private $file;
     private $docParser;
+
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
     private $previousNode;
 
@@ -97,7 +101,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
             $message = sprintf('Can only extract the translation id from a scalar string, but got "%s". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[0]->value), $this->file, $node->args[0]->value->getLine());
 
             if ($this->logger) {
-                $this->logger->err($message);
+                $this->logger->error($message);
                 return;
             }
 
@@ -116,7 +120,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
                 $message = sprintf('Can only extract the translation domain from a scalar string, but got "%s". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[0]->value), $this->file, $node->args[0]->value->getLine());
 
                 if ($this->logger) {
-                    $this->logger->err($message);
+                    $this->logger->error($message);
                     return;
                 }
 

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -36,6 +36,10 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
     private $traverser;
     private $file;
     private $catalogue;
+
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
     private $defaultDomain;
     private $defaultDomainMessages;
@@ -223,7 +227,7 @@ class FormExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
 
             $message = sprintf('Unable to extract translation id for form label/title/placeholder from non-string values, but got "%s" in %s on line %d. Please refactor your code to pass a string, or add "/** @Ignore */".', get_class($item->value), $this->file, $item->value->getLine());
             if ($this->logger) {
-                $this->logger->err($message);
+                $this->logger->error($message);
 
                 return;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT


## Description
We changed the typehints from a symfony log instance to LoggerInterface. The interface functions changed from err() to error(). I've made the same changes in code. I also added the PhpDoc Block annotation for the logger variable

## Todos
- [ ] Tests
- [ ] Documentation
- [ x] Changelog

The Psr\Log\LoggerInterface has no err() function. This
changes all usage of calling err() into calls error(). I also
added PhpDoc Blocks for the class properties.