### PR TITLE
Set xlf as default file format

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 ### 1.2.1 to next release
 
 * Support nikic/php-parser 1.4.x and 2.0.x
+* Set XLF as default output format of the ExtractTranslationCommand
 
 ### 1.2.0 to 1.2.1
 

--- a/Command/ExtractTranslationCommand.php
+++ b/Command/ExtractTranslationCommand.php
@@ -53,7 +53,7 @@ class ExtractTranslationCommand extends ContainerAwareCommand
             ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'The directory where files should be written to.')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'When specified, changes are _NOT_ persisted to disk.')
             ->addOption('output-format', null, InputOption::VALUE_REQUIRED, 'The output format that should be used (in most cases, it is better to change only the default-output-format).')
-            ->addOption('default-output-format', null, InputOption::VALUE_REQUIRED, 'The default output format (defaults to xliff).')
+            ->addOption('default-output-format', null, InputOption::VALUE_REQUIRED, 'The default output format (defaults to xlf).')
             ->addOption('keep', null, InputOption::VALUE_NONE, 'Define if the updater service should keep the old translation (defaults to false).')
             ->addOption('external-translations-dir', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED , 'Load external translation ressources')
         ;

--- a/Tests/Functional/Command/ExtractCommandTest.php
+++ b/Tests/Functional/Command/ExtractCommandTest.php
@@ -42,13 +42,13 @@ class ExtractCommandTest extends BaseCommandTestCase
            .'Directories: '.$inputDir."\n"
            .'Excluded Directories: Tests'."\n"
            .'Excluded Names: *Test.php, *TestCase.php'."\n"
-           .'Output-Format: # whatever is present, if nothing then xliff #'."\n"
+           .'Output-Format: # whatever is present, if nothing then xlf #'."\n"
            .'Custom Extractors: # none #'."\n"
            .'============================================================'."\n"
            .'Loading catalogues from "'.$outputDir.'"'."\n"
            .'Extracting translation keys'."\n"
            .'Extracting messages from directory : '.$inputDir."\n"
-           .'Writing translation file "'.$outputDir.'/messages.en.xliff".'."\n"
+           .'Writing translation file "'.$outputDir.'/messages.en.xlf".'."\n"
            .'done!'."\n"
         ;
 

--- a/Translation/ConfigBuilder.php
+++ b/Translation/ConfigBuilder.php
@@ -25,7 +25,7 @@ final class ConfigBuilder
     private $ignoredDomains = array();
     private $domains = array();
     private $outputFormat;
-    private $defaultOutputFormat = 'xliff';
+    private $defaultOutputFormat = 'xlf';
     private $scanDirs = array();
     private $excludedDirs = array('Tests');
     private $excludedNames = array('*Test.php', '*TestCase.php');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #29 
| License       | MIT


## Description
Set xlf file format as default. Not quite sure if this counts as a BC break, but set it as BC break just in case (the file format is the same as XLIFF, the only difference is the file extension XLF vs XLIFF).

## Todos
- [x] Tests
- [ ] Documentation
- [x] Changelog

