### PR TITLE
Making it possible to extract text from concatenated strings

### DIFF
--- a/Command/ExtractTranslationCommand.php
+++ b/Command/ExtractTranslationCommand.php
@@ -56,6 +56,7 @@ class ExtractTranslationCommand extends ContainerAwareCommand
             ->addOption('default-output-format', null, InputOption::VALUE_REQUIRED, 'The default output format (defaults to xliff).')
             ->addOption('keep', null, InputOption::VALUE_NONE, 'Define if the updater service should keep the old translation (defaults to false).')
             ->addOption('external-translations-dir', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED , 'Load external translation ressources')
+            ->addOption('ignored-annotations', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'The annotations you want to ignore')
         ;
     }
 
@@ -87,6 +88,7 @@ class ExtractTranslationCommand extends ContainerAwareCommand
             $output->writeln(sprintf('Excluded Names: <info>%s</info>', $config->getExcludedNames() ? implode(', ', $config->getExcludedNames()) : '# none #'));
             $output->writeln(sprintf('Output-Format: <info>%s</info>', $config->getOutputFormat() ? $config->getOutputFormat() : '# whatever is present, if nothing then '.$config->getDefaultOutputFormat().' #'));
             $output->writeln(sprintf('Custom Extractors: <info>%s</info>', $config->getEnabledExtractors() ? implode(', ', array_keys($config->getEnabledExtractors())) : '# none #'));
+            $output->writeln(sprintf('Ignored Annotations: <info>%s</info>', $config->getIgnoredAnnotations() ?  implode(', ', $config->getIgnoredAnnotations()) : '# none #'));
             $output->writeln('============================================================');
 
             $updater = $this->getContainer()->get('jms_translation.updater');
@@ -194,6 +196,10 @@ class ExtractTranslationCommand extends ContainerAwareCommand
 
         if ($loadResource = $input->getOption('external-translations-dir')) {
             $builder->setLoadResources($loadResource);
+        }
+
+        if ($annotations = $input->getOption('ignored-annotations')) {
+            $builder->setIgnoredAnnotations($annotations);
         }
     }
 }

--- a/Tests/Functional/Command/ExtractCommandTest.php
+++ b/Tests/Functional/Command/ExtractCommandTest.php
@@ -44,6 +44,7 @@ class ExtractCommandTest extends BaseCommandTestCase
            .'Excluded Names: *Test.php, *TestCase.php'."\n"
            .'Output-Format: # whatever is present, if nothing then xliff #'."\n"
            .'Custom Extractors: # none #'."\n"
+           .'Ignored Annotations: # none #'."\n"
            .'============================================================'."\n"
            .'Loading catalogues from "'.$outputDir.'"'."\n"
            .'Extracting translation keys'."\n"

--- a/Tests/Translation/Extractor/File/DefaultPhpFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/DefaultPhpFileExtractorTest.php
@@ -63,6 +63,11 @@ class DefaultPhpFileExtractorTest extends BasePhpFileExtractorTest
         $message->addSource(new FileSource($path, 82));
         $expected->add($message);
 
+        $message = new Message('Foo Bar Moo');
+        $message->setDesc('Foo Bar Moo');
+        $message->addSource(new FileSource($path, 88));
+        $expected->add($message);
+
         $this->assertEquals($expected, $catalogue);
     }
 
@@ -78,6 +83,10 @@ class DefaultPhpFileExtractorTest extends BasePhpFileExtractorTest
         $message = new Message('baz', 'moo');
         $message->setDesc('Foo Bar');
         $message->addSource(new FileSource($path, 3));
+        $expected->add($message);
+
+        $message = new Message('Foo Bar Moo');
+        $message->addSource(new FileSource($path, 5));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('template.html.php'));

--- a/Tests/Translation/Extractor/File/Fixture/Controller.php
+++ b/Tests/Translation/Extractor/File/Fixture/Controller.php
@@ -81,4 +81,10 @@ class Controller
         /** @Desc("The var %foo% should be assigned.") */
         return $this->translator->trans('text.var.assign', array('%foo%' => 'fooVar'));
     }
+
+    public function concatString()
+    {
+        /** @Desc("Foo Bar Moo") */
+        return $this->translator->trans("Foo" . " Bar" . " Moo");
+    }
 }

--- a/Tests/Translation/Extractor/File/Fixture/template.html.php
+++ b/Tests/Translation/Extractor/File/Fixture/template.html.php
@@ -1,3 +1,5 @@
 <a href="#"><?php echo $view['translator']->trans('foo.bar') ?></a>
 
 <a href="#"><?php echo /** @Desc("Foo Bar") */ $view['translator']->trans('baz', array(), 'moo') ?></a>
+
+<a href="#"><?php echo $view['test']->trans('Foo' . ' Bar' . ' Moo') ?></a>

--- a/Translation/Config.php
+++ b/Translation/Config.php
@@ -43,9 +43,9 @@ final class Config
 
     private $keepOldMessages;
     private $loadResources;
+    private $ignoredAnnotations;
 
-
-    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources)
+    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources, array $ignoredAnnotations)
     {
         if (empty($translationsDir)) {
             throw new InvalidArgumentException('The directory where translations are must be set.');
@@ -85,6 +85,7 @@ final class Config
         $this->enabledExtractors = $enabledExtractors;
         $this->keepOldMessages = $keepOldMessages;
         $this->loadResources = $loadResources;
+        $this->ignoredAnnotations = $ignoredAnnotations;
     }
 
     /**
@@ -207,5 +208,13 @@ final class Config
     public function getLoadResources()
     {
         return $this->loadResources;
+    }
+
+    /**
+     * @return array
+     */
+    public function getIgnoredAnnotations()
+    {
+        return $this->ignoredAnnotations;
     }
 }

--- a/Translation/ConfigBuilder.php
+++ b/Translation/ConfigBuilder.php
@@ -32,6 +32,7 @@ final class ConfigBuilder
     private $enabledExtractors = array();
     private $keepOldTranslations = false;
     private $loadResources = array();
+    private $ignoredAnnotations = array();
 
     /**
      * @static
@@ -52,6 +53,7 @@ final class ConfigBuilder
         $builder->setExcludedNames($config->getExcludedNames());
         $builder->setEnabledExtractors($config->getEnabledExtractors());
         $builder->setLoadResources($config->getLoadResources());
+        $builder->setIgnoredAnnotations($config->getIgnoredAnnotations());
 
         return $builder;
     }
@@ -153,6 +155,7 @@ final class ConfigBuilder
         return $this;
     }
 
+
     public function setExcludedNames(array $names)
     {
         $this->excludedNames = $names;
@@ -202,13 +205,21 @@ final class ConfigBuilder
             $this->excludedNames,
             $this->enabledExtractors,
             $this->keepOldTranslations,
-            $this->loadResources
+            $this->loadResources,
+            $this->ignoredAnnotations
         );
     }
 
     public function setLoadResources(array $loadResources)
     {
         $this->loadResources = $loadResources;
+
+        return $this;
+    }
+
+    public function setIgnoredAnnotations(array $annotations)
+    {
+        $this->ignoredAnnotations = $annotations;
 
         return $this;
     }

--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -156,7 +156,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
 
     private function concatToString($node)
     {
-        if ($node instanceof \PHPParser_Node_Scalar_String) {
+        if ($node instanceof String_) {
             return $node->value;
         } else {
             return self::concatToString($node->left) . self::concatToString($node->right);

--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -33,6 +33,7 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Expr\BinaryOp\Concat;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -98,12 +99,12 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
             }
         }
 
-        if (!$node->args[0]->value instanceof String_) {
+        if (!$node->args[0]->value instanceof String_ and !$node->args[0]->value instanceof Concat) {
             if ($ignore) {
                 return;
             }
 
-            $message = sprintf('Can only extract the translation id from a scalar string, but got "%s". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[0]->value), $this->file, $node->args[0]->value->getLine());
+            $message = sprintf('Can only extract the translation id from a scalar string or a Concat, but got "%s". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[0]->value), $this->file, $node->args[0]->value->getLine());
 
             if ($this->logger) {
                 $this->logger->error($message);
@@ -113,16 +114,20 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
             throw new RuntimeException($message);
         }
 
-        $id = $node->args[0]->value->value;
+        if ($node->args[0]->value instanceof Concat) {
+            $id = $this->concatToString($node->args[0]->value);
+        } else {
+            $id = $node->args[0]->value->value;
+        }
 
         $index = 'trans' === strtolower($node->name) ? 2 : 3;
         if (isset($node->args[$index])) {
-            if (!$node->args[$index]->value instanceof String_) {
+            if (!$node->args[$index]->value instanceof String_ and !$node->args[$index]->value instanceof Concat) {
                 if ($ignore) {
                     return;
                 }
 
-                $message = sprintf('Can only extract the translation domain from a scalar string, but got "%s". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[0]->value), $this->file, $node->args[0]->value->getLine());
+                $message = sprintf('Can only extract the translation domain from a scalar string or a Concat, but got "%s". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[0]->value), $this->file, $node->args[0]->value->getLine());
 
                 if ($this->logger) {
                     $this->logger->error($message);
@@ -132,7 +137,11 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
                 throw new RuntimeException($message);
             }
 
-            $domain = $node->args[$index]->value->value;
+            if ($node->args[$index]->value instanceof Concat) {
+                $domain = $this->concatToString($node->args[$index]->value);
+            } else {
+                $domain = $node->args[$index]->value->value;
+            }
         } else {
             $domain = 'messages';
         }
@@ -143,6 +152,15 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
         $message->addSource(new FileSource((string) $this->file, $node->getLine()));
 
         $this->catalogue->add($message);
+    }
+
+    private function concatToString($node)
+    {
+        if ($node instanceof \PHPParser_Node_Scalar_String) {
+            return $node->value;
+        } else {
+            return self::concatToString($node->left) . self::concatToString($node->right);
+        }
     }
 
     public function visitPhpFile(\SplFileInfo $file, MessageCatalogue $catalogue, array $ast)

--- a/Translation/Extractor/FileExtractor.php
+++ b/Translation/Extractor/FileExtractor.php
@@ -32,6 +32,7 @@ use JMS\TranslationBundle\Twig\RemovingNodeVisitor;
 use JMS\TranslationBundle\Translation\ExtractorInterface;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use Symfony\Component\Finder\Finder;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 /**
  * File-based extractor.
@@ -49,6 +50,7 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
     private $defaultApplyingTwigVisitor;
     private $excludedNames = array();
     private $excludedDirs = array();
+    private $ignoredAnnotations = array();
     private $logger;
 
     public function __construct(\Twig_Environment $twig, LoggerInterface $logger, array $visitors)
@@ -112,6 +114,11 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
         $this->excludedNames = $names;
     }
 
+    public function setIgnoredAnnotations(array $annotations)
+    {
+        $this->ignoredAnnotations = $annotations;
+    }
+
     public function setPattern(array $pattern)
     {
         $this->pattern = $pattern;
@@ -138,6 +145,10 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
 
         if ($this->pattern) {
             $finder->name($this->pattern);
+        }
+
+        foreach ($this->ignoredAnnotations as $annotation) {
+            AnnotationReader::addGlobalIgnoredName($annotation);
         }
 
         $curTwigLoader = $this->twig->getLoader();

--- a/Translation/Extractor/FileExtractor.php
+++ b/Translation/Extractor/FileExtractor.php
@@ -154,7 +154,7 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
                 if (false !== $pos = strrpos($file, '.')) {
                     $extension = substr($file, $pos + 1);
 
-                    if ('php' === $extension) {
+                    if ('php' === $extension or 'phtml' === $extension) {
                         try {
                             $ast = $this->phpParser->parse(file_get_contents($file));
                         } catch (Error $ex) {
@@ -165,7 +165,7 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
                         $visitingArgs[] = $ast;
                     } else if ('twig' === $extension) {
                         $visitingMethod = 'visitTwigFile';
-                        $visitingArgs[] = $this->twig->parse($this->twig->tokenize(file_get_contents($file), (string) $file));
+                        $visitingArgs[] = $this->twig->parse($this->twig->tokenize(file_get_contents($file), (string)$file));
                     }
                 }
 

--- a/Translation/ExtractorManager.php
+++ b/Translation/ExtractorManager.php
@@ -126,6 +126,15 @@ class ExtractorManager implements ExtractorInterface
     }
 
     /**
+     * @param array $annotations
+     *
+     */
+    public function setIgnoredAnnotations(array $annotations)
+    {
+        $this->fileExtractor->setIgnoredAnnotations($annotations);
+    }
+
+    /**
      * @return \JMS\TranslationBundle\Model\MessageCatalogue
      */
     public function extract()

--- a/Translation/Updater.php
+++ b/Translation/Updater.php
@@ -229,6 +229,7 @@ class Updater
         $this->extractor->setExcludedDirs($config->getExcludedDirs());
         $this->extractor->setExcludedNames($config->getExcludedNames());
         $this->extractor->setEnabledExtractors($config->getEnabledExtractors());
+        $this->extractor->setIgnoredAnnotations($config->getIgnoredAnnotations());
 
         $this->logger->info("Extracting translation keys");
         $this->scannedCatalogue = $this->extractor->extract();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #296
| License       | MIT


## Description
Just added a small change so in case you have a long concatenated strings in your code, you can use the bundle to extract those strings into your translation files. It basically converts the concatenated strings into one string before passing it to extraction.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog
