### PR TITLE
Hotfix handle symfony placeholders

### DIFF
--- a/Model/Message.php
+++ b/Model/Message.php
@@ -255,10 +255,6 @@ class Message
 
         if (null !== $desc = $message->getDesc()) {
             $this->desc = $desc;
-            $this->localeString = null;
-            if ($localeString = $message->getLocaleString()) {
-                $this->localeString = $localeString;
-            }
         }
 
         foreach ($message->getSources() as $source) {

--- a/Tests/Translation/Extractor/File/Fixture/MyPlaceholderFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyPlaceholderFormType.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\TranslationBundle\Tests\Translation\Extractor\File\Fixture;
+
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\AbstractType;
+
+class MyPlaceholderFormType extends AbstractType
+{
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        $builder
+            ->add('field_with_attr_placeholder', 'text', array(
+                'label' => 'field.with.placeholder',
+                'attr' => array('placeholder' => /** @Desc("Field with a placeholder value") */ 'form.placeholder.text')
+            ))
+            ->add('field_without_label_with_attr_placeholder', 'text', array(
+                'label' => false,
+                'attr' => array('placeholder' => /** @Desc("Field with a placeholder but no label") */ 'form.placeholder.text.but.no.label')
+            ))
+            ->add('field_placeholder', 'choice', array(
+                'placeholder' => /** @Desc("Choice field with a placeholder") */ 'form.choice_placeholder'
+            ))
+            ->add('field_empty_value', 'choice', array(
+                'empty_value' => /** @Desc("Choice field with an empty_value") */ 'form.choice_empty_value'
+            ))
+        ;
+    }
+}

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -36,6 +36,9 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
      */
     private $extractor;
 
+    /**
+     * @group testExtract
+     */
     public function testExtract()
     {
         $expected = new MessageCatalogue();

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -37,6 +37,41 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
     private $extractor;
 
     /**
+     * @group placeholder
+     */
+    public function testPlaceholderExtract()
+    {
+        $expected = new MessageCatalogue();
+        $path = __DIR__.'/Fixture/MyPlaceholderFormType.php';
+
+        $message = new Message('field.with.placeholder');
+        $message->addSource(new FileSource($path, 29));
+        $expected->add($message);
+
+        $message = new Message('form.placeholder.text');
+        $message->setDesc('Field with a placeholder value');
+        $message->addSource(new FileSource($path, 30));
+        $expected->add($message);
+
+        $message = new Message('form.placeholder.text.but.no.label');
+        $message->setDesc('Field with a placeholder but no label');
+        $message->addSource(new FileSource($path, 34));
+        $expected->add($message);
+
+        $message = new Message('form.choice_placeholder');
+        $message->setDesc('Choice field with a placeholder');
+        $message->addSource(new FileSource($path, 37));
+        $expected->add($message);
+
+        $message = new Message('form.choice_empty_value');
+        $message->setDesc('Choice field with an empty_value');
+        $message->addSource(new FileSource($path, 40));
+        $expected->add($message);
+
+        $this->assertEquals($expected, $this->extract('MyPlaceholderFormType.php'));
+    }
+
+    /**
      * @group testExtract
      */
     public function testExtract()

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -124,6 +124,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
                     case 'invalid_message':
                         $this->parseItem($item, 'validators');
                         break;
+                    case 'placeholder':
                     case 'empty_value':
                         if ($this->parseEmptyValueNode($item, $domain)) {
                             continue 2;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT


## Description
This adds placeholder extraction handling (attr placeholder extraction was already supported) However placeholder instead of empty_value was not. What I find extremely odd is the change to the Message->merge() function which was required to fix the tests where the catalogue was getting a null localeString after merging when it shouldn't have.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
