### PR TITLE
Default Symfony xliff dumper should be used instead of JMS

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -61,10 +61,9 @@
             </call>
             <tag name="jms_translation.dumper" format="xliff" />
         </service>
-        <service id="jms_translation.dumper.xlf_dumper" class="%jms_translation.dumper.xliff_dumper.class%" public="false">
-            <call method="setSourceLanguage">
-                <argument>%jms_translation.source_language%</argument>
-            </call>
+        <service id="jms_translation.dumper.xlf_dumper" class="%jms_translation.dumper.symfony_adapter.class%" public="false">
+            <argument type="service" id="translation.dumper.xliff" />
+            <argument>xlf</argument>
             <tag name="jms_translation.dumper" format="xlf" />
         </service>
         <service id="jms_translation.dumper.yaml_dumper" class="%jms_translation.dumper.yaml_dumper.class%" public="false">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT


## Description
We are using the XLIFF dumper made in JMSTranslationBundle with the extractor.
We should be using the XliffFileDumper from Symfony for all the default extraction. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog

