### PR TITLE
Check response content when update message

### DIFF
--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -82,6 +82,6 @@ class ApiController
             $request->request->get('message')
         );
 
-        return new Response();
+        return new Response('Translation was saved');
     }
 }

--- a/Resources/views/Translate/index.html.twig
+++ b/Resources/views/Translate/index.html.twig
@@ -25,8 +25,12 @@
                         error: function() {
                             $(self).parent().closest('td').prev('td').append('<span class="alert-message label error">Could not be saved.</span>');
                         },
-                        success: function() {
-                            $(self).parent().closest('td').prev('td').append('<span class="alert-message label success">Translation was saved.</span>');
+                        success: function(data) {
+                            if (data == 'Translation was saved') {
+                                $(self).parent().closest('td').prev('td').append('<span class="alert-message label success">Translation was saved.</span>');
+                            } else {
+                                $(self).parent().closest('td').prev('td').append('<span class="alert-message label error">Could not be saved.</span>');
+                            }
                         },
                         complete: function() {
                             var parent = $(self).parent();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT


## Description
I think we need to check the content of the ajax request when we update message, here an example:
- My security.yml allow access to `translations/` only for ROLE_ADMIN
- With an another tab, I logout from my admin account
- I try to update a translation: I'm not connected, so the ajax request to `translations/?config=test&domain=messages&locale=fr` is redirected with 302 to my login page which are a 200 Response.
- Ajax got a 200 Response, it display "Translation was saved" but in fact, not...
(jQuery ajax don't care about the 302, he follow the link)
