### PR TITLE
Handle attr as a variable

### DIFF
--- a/Tests/Translation/Extractor/File/Fixture/MyAttrArrayType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyAttrArrayType.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\TranslationBundle\Tests\Translation\Extractor\File\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class MyAttrArrayType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $attr = array('something'=>'whatever');
+
+        $builder
+            ->add('firstname', 'text', array(
+                'label' => 'form.label.firstname',
+            ))
+            ->add('field_with_attr_as_array','text',array(
+            'attr'=>$attr
+        ));
+    }
+
+}

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -282,4 +282,17 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
 
         return $catalogue;
     }
+
+    public function testAttrArrayForm()
+    {
+        $expected = new MessageCatalogue();
+        $path = __DIR__.'/Fixture/MyAttrArrayType.php';
+
+        $message = new Message('form.label.firstname');
+        $message->addSource(new FileSource($path, 31));
+        $expected->add($message);
+
+        $this->assertEquals($expected, $this->extract('MyAttrArrayType.php'));
+
+    }
 }

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -170,7 +170,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
                         }
                         $this->parseItem($sitem, $domain);
                     }
-                } elseif ('attr' === $item->key->value && is_array($item->value->items)) {
+                } elseif ('attr' === $item->key->value && $item->value instanceof Node\Expr\Array_) {
                     foreach ($item->value->items as $sitem) {
                         if ('placeholder' == $sitem->key->value) {
                             $this->parseItem($sitem, $domain);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #340
| License       | MIT

## Description
Somehow I accidentally closed my original PR of #339 this is the same PR but modified as requested to not change the tests but add a new test for this situation.

If you have a form class with the following buildForm
```
public function buildForm(FormBuilderInterface $builder, array $options)
{
        $attr1 = array(
            'data-context-child'  => 'stool1Reminder',
            'data-context-value'  => TripleChoice::YES);
        $builder->add('fieldName', 'formType', array('attr' => $attr1));
}
```
you will get an exception:
Notice: Undefined property: PhpParser\Node\Expr\Variable::$items  
thrown from line 173 in Translation/Extractor/File/FormExtractor.php the following patch fixes that behaviour.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog

if the form option 'attr' is a variable we fail since
we didn't check the node type and assume it isn't a variable.