### PR TITLE
fix tests broken by merges

### DIFF
--- a/Tests/Translation/Dumper/XliffDumperTest.php
+++ b/Tests/Translation/Dumper/XliffDumperTest.php
@@ -53,6 +53,15 @@ EOF;
         $this->assertEquals($expected, $dumper->dump($catalogue, 'messages'));
     }
 
+    public function testDumpStructureFullPaths()
+    {
+        $dumper = $this->getDumper();
+
+        $catalogue = $this->getStructureCatalogue();
+
+        $this->assertEquals($this->getOutput('structure'), $dumper->dump($catalogue, 'messages'));
+    }
+
     /**
      * * Test the fact that the references positions are not in the dumped xliff
      */

--- a/Tests/Translation/Dumper/xliff/structure_without_reference_position.xml
+++ b/Tests/Translation/Dumper/xliff/structure_without_reference_position.xml
@@ -9,7 +9,7 @@
       <trans-unit id="fb2d5a853a8edd799b4084a828d7d6746210534b" resname="foo.bar.baz">
         <source>foo.bar.baz</source>
         <target state="new">foo.bar.baz</target>
-        <jms:reference-file>c/foo/bar</jms:reference-file>
+        <jms:reference-file>/a/b/c/foo/bar</jms:reference-file>
         <jms:reference-file>bar/baz</jms:reference-file>
       </trans-unit>
     </body>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT


## Description
The previous merge #331 was applied after a test the add/setReference to the dumper interface. So initially the tests passed but after application failed to pass. This fixes the tests.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog

