### PR TITLE
Move inline JS to a class

### DIFF
--- a/Resources/public/js/jms.js
+++ b/Resources/public/js/jms.js
@@ -1,0 +1,198 @@
+/**
+ * JMSTranslationManager
+ *
+ * JS object that drives AJAX functionality on JMS Translation Bundle UI
+ *
+ *  Constructor arguments:
+ *  @string updateMessagePath: uri to which translation data is sent
+ *  @boolean isWritable: Whether the source translation files are actually writable
+ *
+ *  Configuration:
+ *  @object domain
+ *      @string selector: jquery selector for domain changer fields
+ *      @function handlers: event handlers to be attached to domain fields
+ *
+ *  @object truncator
+ *      @string selector: jquery selector for fields to be truncated (requires Trunk8 JQuery plugin)
+ *      @string side: left|right side to truncate
+ *      @string fill: html element to use to untruncate text
+ *      @string untruncateSelector: jquery selector for fill field, used by handlers in default truncate function
+ *      @function truncate: function that actually defines the truncation behaviour
+ *
+ *  @object translation
+ *      @string selector: jquery selector for field that will contain the translation text
+ *      @object ajax
+ *          @string type: http request type for ajax request
+ *          @object headers: http headers to be sent with request
+ *          @string dataMethod: ajax _dataMethod
+ *          @function beforeSend|error|success|complete: ajax request event handlers
+ *          @string errorMessageContent|savedMessageContent|unsavedMessageContent: message text used by the default ajax request handlers
+ *      @function blur: translation field onBlur handler
+ *      @function focus: translation field onFocus handler
+ *
+ *  @function ready: inits the JMSTranslationManager
+ *
+ *  @function writable: attaches translation field handlers if isWritable is true
+ */
+function JMSTranslationManager(updateMessagePath, isWritable)
+{
+    if(!window.jQuery)
+    {
+        console.error('JMSTranslationManager requires JQuery.');
+        return;
+    }
+
+    this.updateMessagePath = updateMessagePath;
+    this.isWritable        = isWritable ? isWritable : false;
+
+    this.domain  = {
+        selector: '#config select',
+        handlers: function(JMS)
+        {
+            $(JMS.domain.selector).change(function() {
+                $(this).parent().submit();
+            });
+        }
+    };
+
+    this.truncator = {
+        selector: '.truncate-left',
+        side:     'left',
+        fill:     '<a href="#" class="untruncate">&hellip;</a>',
+        untruncateSelector: '.untruncate',
+        truncate: function(JMS)
+        {
+            if(jQuery().trunk8)
+            {
+                $(JMS.truncator.selector).trunk8({
+                    side: JMS.truncator.side,
+                    fill: JMS.truncator.fill
+                });
+
+                $(document).on('click', JMS.truncator.untruncateSelector, function (event) {
+                    var $elem = $(this);
+                    $elem.parent().trunk8('revert');
+                    event.preventDefault();
+                });
+            }
+            else
+            {
+                console.error('Truncator requires jQuery Trunk8 plugin.');
+            }
+        }
+    };
+
+    this.translation = {
+        selector: 'textarea',
+        ajax: {
+            type: 'POST',
+            headers: {'X-HTTP-METHOD-OVERRIDE': 'PUT'},
+            dataMethod: 'PUT',
+            beforeSend: function(data, event, JMS)
+            {
+                var $elem = $(event.target);
+                $elem.parent().closest('td').prev('td').children('.alert-message').remove();
+            },
+            error: function(data, event, JMS)
+            {
+                var $elem = $(event.target);
+                $elem.parent().closest('td').prev('td').append(JMS.translation.ajax.errorMessageContent);
+            },
+            errorMessageContent: '<span class="alert-message label error">Could not be saved.</span>',
+            success: function(data, event, JMS)
+            {
+                var $elem = $(event.target);
+
+                if (data == 'Translation was saved')
+                {
+                    $elem.parent().closest('td').prev('td').append(JMS.translation.ajax.savedMessageContent);
+                } else
+                {
+                    $elem.parent().closest('td').prev('td').append(JMS.translation.ajax.unsavedMessageContent);
+                }
+            },
+            savedMessageContent: '<span class="alert-message label success">Translation was saved.</span>',
+            unsavedMessageContent: '<span class="alert-message label error">Could not be saved.</span>',
+            complete: function(data, event, JMS)
+            {
+                var $elem = $(event.target);
+                var $parent = $elem.parent();
+                $elem.data('timeoutId', setTimeout(function ()
+                {
+                    $elem.data('timeoutId', undefined);
+                    $parent.closest('td').prev('td').children('.alert-message').fadeOut(300, function ()
+                    {
+                        var $message = $(this);
+                        $message.remove();
+                    });
+                }, 10000));
+            }
+        },
+        blur: function(event, JMS)
+        {
+            var $elem = $(event.target);
+            $.ajax(JMS.updateMessagePath + '?id=' + encodeURIComponent($elem.data('id')), {
+                type: JMS.translation.ajax.type,
+                headers: JMS.translation.ajax.headers,
+                data: {'_method': JMS.translation.ajax.dataMethod, 'message': $elem.val()},
+                beforeSend: function (data)
+                {
+                    JMS.translation.ajax.beforeSend(data, event, JMS);
+                },
+                error: function (data)
+                {
+                    JMS.translation.ajax.error(data, event, JMS);
+                },
+                success: function (data)
+                {
+                    JMS.translation.ajax.success(data, event, JMS);
+                },
+                complete: function (data)
+                {
+                    JMS.translation.ajax.complete(data, event, JMS);
+                }
+            });
+        },
+        focus: function(event, JMS)
+        {
+            var $elem = $(event.target);
+            $elem.select();
+
+            var timeoutId = $elem.data('timeoutId');
+            if (timeoutId)
+            {
+                clearTimeout(timeoutId);
+                $elem.data('timeoutId', undefined);
+            }
+
+            $elem.parent().children('.alert-message').remove();
+        }
+    };
+
+    this.ready = function()
+    {
+        var JMS = this;
+        $(document).ready(function(event) {
+            JMS.domain.handlers(JMS);
+            JMS.truncator.truncate(JMS);
+            if(JMS.isWritable)
+            {
+                JMS.writable(JMS);
+            }
+        });
+    };
+
+    this.writable = function(JMS)
+    {
+        $(JMS.translation.selector)
+            .blur(function(event)
+            {
+                JMS.translation.blur(event, JMS);
+            })
+            .focus(function ()
+            {
+                JMS.translation.focus(event, JMS);
+            })
+        ;
+    };
+};

--- a/Resources/views/Translate/index.html.twig
+++ b/Resources/views/Translate/index.html.twig
@@ -2,69 +2,12 @@
 
 {% block javascripts %}
     {{ parent() }}
-    
     <script language="javascript" type="text/javascript">
-        $(document).ready(function() {
-            var updateMessagePath = {{ path("jms_translation_update_message", {"config": selectedConfig, "domain": selectedDomain, "locale": selectedLocale})|json_encode|raw }};
-        
-            $('#config select').change(function() {
-                $(this).parent().submit();
-            });
-            
-            $('.truncate-left').trunk8({
-                side: 'left',
-                fill: '<a href="#" class="untruncate">&hellip;</a>'
-            });
+        var updateMessagePath = {{ path("jms_translation_update_message", {"config": selectedConfig, "domain": selectedDomain, "locale": selectedLocale})|json_encode|raw }};
+        var isWritable        = {{ isWriteable is sameas(true) ? 'true' : 'false' }};
+        var JMS               = new JMSTranslationManager(updateMessagePath, isWritable);
 
-            $(document).on('click', '.untruncate', function (event) {
-                $(this).parent().trunk8('revert');
-                event.preventDefault();
-            });
-            
-            {% if isWriteable is sameas(true) %}
-            $('textarea')
-                .blur(function() {
-                    var self = this;
-                    $.ajax(updateMessagePath + '?id=' + encodeURIComponent($(this).data('id')), {
-                        type: 'POST',
-                        headers: {'X-HTTP-METHOD-OVERRIDE': 'PUT'},
-                        data: {'_method': 'PUT', 'message': $(this).val()},
-                        beforeSend: function() {
-                            $(self).parent().closest('td').prev('td').children('.alert-message').remove();
-                        },
-                        error: function() {
-                            $(self).parent().closest('td').prev('td').append('<span class="alert-message label error">Could not be saved.</span>');
-                        },
-                        success: function(data) {
-                            if (data == 'Translation was saved') {
-                                $(self).parent().closest('td').prev('td').append('<span class="alert-message label success">Translation was saved.</span>');
-                            } else {
-                                $(self).parent().closest('td').prev('td').append('<span class="alert-message label error">Could not be saved.</span>');
-                            }
-                        },
-                        complete: function() {
-                            var parent = $(self).parent();
-                            $(self).data('timeoutId', setTimeout(function() {
-                                $(self).data('timeoutId', undefined);
-                                parent.closest('td').prev('td').children('.alert-message').fadeOut(300, function() { $(this).remove(); });
-                            }, 10000));
-                        }
-                    });
-                })
-                .focus(function() {
-                    this.select();
-                    
-                    var timeoutId = $(this).data('timeoutId');
-                    if (timeoutId) {
-                        clearTimeout(timeoutId);
-                        $(this).data('timeoutId', undefined);
-                    }
-                    
-                    $(this).parent().children('.alert-message').remove();
-                })
-            ;
-            {% endif %}
-        });
+        JMS.ready();
     </script>
 {% endblock %}
 

--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -24,6 +24,7 @@
         {% block javascripts %}
         <script language="javascript" type="text/javascript" src="{{ asset("bundles/jmstranslation/js/jquery.js") }}"></script>
         <script language="javascript" type="text/javascript" src="{{ asset("bundles/jmstranslation/js/trunk8.js") }}"></script>
+            <script type="text/javascript" src="{{ asset("/bundles/jmstranslation/js/jms.js") }}"></script>
         {% endblock %}
     </body>
 </html>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

The formerly inline javascript from Resources/views/Translate/index.html.twig has been moved to an external file and turned into a class so functionality can be extended/overridden
