### PR TITLE
Fix extraction for global namespace

### DIFF
--- a/Tests/Translation/Extractor/FileExtractorTest.php
+++ b/Tests/Translation/Extractor/FileExtractorTest.php
@@ -76,6 +76,12 @@ class FileExtractorTest extends \PHPUnit_Framework_TestCase
             $message->addSource(new FileSource($basePath.'Resources/views/'.$engine.'_template.html.'.$engine, 7));
             $expected[$engine.'.foo_bar'] = $message;
         }
+		
+		// File with global namespace.
+        $message = new Message('globalnamespace.foo');
+        $message->addSource(new FileSource($basePath.'GlobalNamespace.php', 27));
+        $message->setDesc('Bar');
+        $expected['globalnamespace.foo'] = $message;
 
         $actual = $this->extract(__DIR__.'/Fixture/SimpleTest')->getDomain('messages')->all();
 

--- a/Tests/Translation/Extractor/FileExtractorTest.php
+++ b/Tests/Translation/Extractor/FileExtractorTest.php
@@ -76,8 +76,8 @@ class FileExtractorTest extends \PHPUnit_Framework_TestCase
             $message->addSource(new FileSource($basePath.'Resources/views/'.$engine.'_template.html.'.$engine, 7));
             $expected[$engine.'.foo_bar'] = $message;
         }
-		
-		// File with global namespace.
+
+        // File with global namespace.
         $message = new Message('globalnamespace.foo');
         $message->addSource(new FileSource($basePath.'GlobalNamespace.php', 27));
         $message->setDesc('Bar');

--- a/Tests/Translation/Extractor/Fixture/SimpleTest/GlobalNamespace.php
+++ b/Tests/Translation/Extractor/Fixture/SimpleTest/GlobalNamespace.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace
+{
+    class SomeRandomClassNameWhichIsnTUsedAnywhereJMSTranslatorTest
+    {
+        private $translator;
+
+        public function method()
+        {
+            return /** @Desc("Bar") */ $this->translator->trans('globalnamespace.foo');
+        }
+    }
+}

--- a/Translation/Extractor/File/AuthenticationMessagesExtractor.php
+++ b/Translation/Extractor/File/AuthenticationMessagesExtractor.php
@@ -114,7 +114,9 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
     public function enterNode(Node $node)
     {
         if ($node instanceof Node\Stmt\Namespace_) {
-            $this->namespace = implode('\\', $node->name->parts);
+            if (isset($node->name)) {
+                $this->namespace = implode('\\', $node->name->parts);
+            }
 
             return;
         }

--- a/Translation/Extractor/File/TranslationContainerExtractor.php
+++ b/Translation/Extractor/File/TranslationContainerExtractor.php
@@ -77,7 +77,9 @@ class TranslationContainerExtractor implements FileVisitorInterface, NodeVisitor
     public function enterNode(Node $node)
     {
         if ($node instanceof Node\Stmt\Namespace_) {
-            $this->namespace = implode('\\', $node->name->parts);
+            if (isset($node->name)) {
+                $this->namespace = implode('\\', $node->name->parts);
+            }
             $this->useStatements = array();
 
             return;

--- a/Translation/Extractor/File/ValidationExtractor.php
+++ b/Translation/Extractor/File/ValidationExtractor.php
@@ -86,7 +86,9 @@ class ValidationExtractor implements FileVisitorInterface, NodeVisitor
     public function enterNode(Node $node)
     {
         if ($node instanceof Node\Stmt\Namespace_) {
-            $this->namespace = implode('\\', $node->name->parts);
+            if (isset($node->name)) {
+                $this->namespace = implode('\\', $node->name->parts);
+            }
 
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #223, #201
| License       | MIT


## Description
This replaces #223. Extraction fails if a PHP file contains the global namespace keyword.