### PR TITLE
Change deprecated twig filter

### DIFF
--- a/Resources/views/Translate/messages.html.twig
+++ b/Resources/views/Translate/messages.html.twig
@@ -14,7 +14,7 @@
                     <p><abbr title="{{ id }}">{{ id|slice(0, 25) }}{% if id|length > 25 %}...{% endif %}</abbr></p>
                 </td>
                 <td>
-                    <textarea data-id="{{ id }}" class="span6"{% if isWriteable is sameas(false) %} readonly="readonly"{% endif %}>{{ message.localeString }}</textarea></td>
+                    <textarea data-id="{{ id }}" class="span6"{% if isWriteable is same as(false) %} readonly="readonly"{% endif %}>{{ message.localeString }}</textarea></td>
                 <td>
                     {% if message.meaning is not empty %}
                         <h6>Meaning</h6>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
Changing `sameas` twig filter to `same as` because `sameas` is deprecated.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog

Change `sameas` twig filter to `same as` filter as it is deprecated