### PR TITLE
Added option to keep initial translated messages

### DIFF
--- a/Command/ExtractTranslationCommand.php
+++ b/Command/ExtractTranslationCommand.php
@@ -59,6 +59,7 @@ class ExtractTranslationCommand extends ContainerAwareCommand
             ->addOption('default-output-format', null, InputOption::VALUE_REQUIRED, 'The default output format (defaults to xlf).')
             ->addOption('keep', null, InputOption::VALUE_NONE, 'Define if the updater service should keep the old translation (defaults to false).')
             ->addOption('external-translations-dir', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Load external translation resources')
+            ->addOption('keeptm', null, InputOption::VALUE_NONE, 'Define if the updater service should keep the old translation messages (defaults to false).')
         ;
     }
 
@@ -89,6 +90,7 @@ class ExtractTranslationCommand extends ContainerAwareCommand
 
             $output->writeln(sprintf('Extracting Translations for locale <info>%s</info>', $locale));
             $output->writeln(sprintf('Keep old translations: <info>%s</info>', $config->isKeepOldMessages() ? 'Yes' : 'No'));
+            $output->writeln(sprintf('Keep old translations messages: <info>%s</info>', $config->isKeepOldTranslationsMessages() ? 'Yes' : 'No'));
             $output->writeln(sprintf('Output-Path: <info>%s</info>', $config->getTranslationsDir()));
             $output->writeln(sprintf('Directories: <info>%s</info>', implode(', ', $config->getScanDirs())));
             $output->writeln(sprintf('Excluded Directories: <info>%s</info>', $config->getExcludedDirs() ? implode(', ', $config->getExcludedDirs()) : '# none #'));
@@ -123,6 +125,10 @@ class ExtractTranslationCommand extends ContainerAwareCommand
                             $output->writeln($message->getId(). '-> '.$message->getDesc());
                         }
                     }
+                }
+
+                if ($config->isKeepOldTranslationsMessages()) {
+                    $output->writeln('Not keeping old Translations Messages');
                 }
 
                 return;
@@ -202,6 +208,12 @@ class ExtractTranslationCommand extends ContainerAwareCommand
             $builder->setKeepOldTranslations(true);
         } elseif ($input->hasParameterOption('--keep=false')) {
             $builder->setKeepOldTranslations(false);
+        }
+
+        if ($input->hasParameterOption('--keeptm') || $input->hasParameterOption('--keeptm=true')) {
+            $builder->setKeepOldTranslationsMessages(true);
+        } else if ($input->hasParameterOption('--keeptm=false')) {
+            $builder->setKeepOldTranslationsMessages(false);
         }
 
         if ($loadResource = $input->getOption('external-translations-dir')) {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -38,6 +38,7 @@
             <argument type="service" id="jms_translation.extractor_manager" />
             <argument type="service" id="logger" />
             <argument type="service" id="jms_translation.file_writer" />
+            <argument type="service" id="translator.default" />
         </service>
         
         <service id="jms_translation.config_factory" class="%jms_translation.config_factory.class%" />

--- a/Tests/Functional/Command/ExtractCommandTest.php
+++ b/Tests/Functional/Command/ExtractCommandTest.php
@@ -37,7 +37,8 @@ class ExtractCommandTest extends BaseCommandTestCase
 
         $expectedOutput =
             'Extracting Translations for locale en'."\n"
-           .'Keep old translations: No'."\n"
+           .'Keep old translations: No'."\n" 
+           .'Keep old translations messages: No'."\n"
            .'Output-Path: '.$outputDir."\n"
            .'Directories: '.$inputDir."\n"
            .'Excluded Directories: Tests'."\n"

--- a/Translation/Config.php
+++ b/Translation/Config.php
@@ -86,6 +86,11 @@ final class Config
     private $keepOldMessages;
 
     /**
+     * @var bool
+     */
+    private $keepOldTranslationsMessages;
+
+    /**
      * @var array
      */
     private $loadResources;
@@ -103,9 +108,10 @@ final class Config
      * @param array $excludedNames
      * @param array $enabledExtractors
      * @param bool $keepOldMessages
+     * @param bool $keepOldTranslationsMessages
      * @param array $loadResources
      */
-    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources)
+    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, $keepOldTranslationsMessages, array $loadResources)
     {
         if (empty($translationsDir)) {
             throw new InvalidArgumentException('The directory where translations are must be set.');
@@ -144,6 +150,7 @@ final class Config
         $this->excludedNames = $excludedNames;
         $this->enabledExtractors = $enabledExtractors;
         $this->keepOldMessages = $keepOldMessages;
+        $this->keepOldTranslationsMessages = $keepOldTranslationsMessages;
         $this->loadResources = $loadResources;
     }
 
@@ -259,6 +266,14 @@ final class Config
     public function isKeepOldMessages()
     {
         return $this->keepOldMessages;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isKeepOldTranslationsMessages()
+    {
+        return $this->keepOldTranslationsMessages;
     }
 
     /**

--- a/Translation/ConfigBuilder.php
+++ b/Translation/ConfigBuilder.php
@@ -76,6 +76,11 @@ final class ConfigBuilder
     private $keepOldTranslations = false;
 
     /**
+     * @var bool
+     */
+    private $keepOldTranslationsMessages  = false;
+
+    /**
      * @var array
      */
     private $loadResources = array();
@@ -286,6 +291,17 @@ final class ConfigBuilder
     }
 
     /**
+     * @param bool $value
+     * @return $this
+     */
+    public function setKeepOldTranslationsMessages($value)
+    {
+        $this->keepOldTranslationsMessages = $value;
+
+        return $this;
+    }
+
+    /**
      * @return Config
      */
     public function getConfig()
@@ -302,6 +318,7 @@ final class ConfigBuilder
             $this->excludedNames,
             $this->enabledExtractors,
             $this->keepOldTranslations,
+            $this->keepOldTranslationsMessages,
             $this->loadResources
         );
     }

--- a/Translation/Updater.php
+++ b/Translation/Updater.php
@@ -24,6 +24,7 @@ use JMS\TranslationBundle\Exception\RuntimeException;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Comparison\CatalogueComparator;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Finder\Finder;
 
 /**
@@ -73,17 +74,23 @@ class Updater
     private $writer;
 
     /**
+     * @var Translator
+     */
+    private $translator;
+
+    /**
      * @param LoaderManager $loader
      * @param ExtractorManager $extractor
      * @param LoggerInterface $logger
      * @param FileWriter $writer
      */
-    public function __construct(LoaderManager $loader, ExtractorManager $extractor, LoggerInterface $logger, FileWriter $writer)
+    public function __construct(LoaderManager $loader, ExtractorManager $extractor, LoggerInterface $logger, FileWriter $writer, Translator $translator)
     {
         $this->loader = $loader;
         $this->extractor = $extractor;
         $this->logger = $logger;
         $this->writer = $writer;
+        $this->translator = $translator;
     }
 
     /**
@@ -277,5 +284,23 @@ class Updater
                 }
             }
         }
+
+        //keep old translations translated
+        if ($this->config->isKeepOldTranslationsMessages()) {
+
+            $locale = $this->scannedCatalogue->getLocale();
+            /** @var MessageCatalogue $domainCatalogue */
+            foreach ($this->scannedCatalogue->getDomains() as $domainCatalogue) {
+
+                /** @var Message $message */
+                foreach ($domainCatalogue->all() as $message) {
+
+                    $translated = $this->translator->trans($message->getId(), array(), $message->getDomain(), $locale);
+                    $message->setLocaleString($translated);
+                    $message->setNew(false);
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | Apache2


## Description
I've remade [this PR](https://github.com/schmittjoh/JMSTranslationBundle/pull/292) on branch master, without whitespace changes.

The idea was to do [this](https://github.com/schmittjoh/JMSTranslationBundle/issues/277), so I added an option ``--keeptm`` which will keep your already defined translation messages.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog

