### PR TITLE
Display available format list for invalid format exception

### DIFF
--- a/Translation/FileWriter.php
+++ b/Translation/FileWriter.php
@@ -52,7 +52,9 @@ class FileWriter
     public function write(MessageCatalogue $catalogue, $domain, $filePath, $format)
     {
         if (!isset($this->dumpers[$format])) {
-            throw new InvalidArgumentException(sprintf('The format "%s" is not supported.', $format));
+            $allowedFormats = array_keys($this->dumpers);
+            $allowedFormatsString = join(',', $allowedFormats);
+            throw new InvalidArgumentException(sprintf('The format "%s" is not supported. Allowed formats:%s', $format, $allowedFormatsString));
         }
 
         // sort messages before dumping


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
When using an invalid output format, you get an exception. I only updated the exception message  adding the list of allowed formats.

