### PR TITLE
Allow extending of the Extractor for custom form options

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 * Various extraction bug fixes (attr as variable)
 * Various improvements to xliff dumper
 * Ensure full symfony 3.0 support and tests
+* Added ability to extend the FormExtractor
 
 ### 1.2.1 to 1.2.2
 

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -65,12 +65,12 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
     /**
      * @var string
      */
-    private $defaultDomain;
+    protected $defaultDomain;
 
     /**
      * @var string
      */
-    private $defaultDomainMessages;
+    protected $defaultDomainMessages;
 
     /**
      * FormExtractor constructor.
@@ -204,7 +204,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
     }
 
     /**
-     * This parses any Node of type choices. 
+     * This parses any Node of type choices.
      *
      * Returning true means either that regardless of whether
      * parsing has occurred or not, the enterNode function should move on to the next node item.
@@ -246,7 +246,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
     }
 
     /**
-     * This parses any Node of type attr 
+     * This parses any Node of type attr
      *
      * Returning true means either that regardless of whether
      * parsing has occurred or not, the enterNode function should move on to the next node item.
@@ -278,12 +278,12 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
     /**
      * @param Node $node
      */
-    private function parseDefaultsCall(Node $node)
+    protected function parseDefaultsCall(Node $node)
     {
         static $returningMethods = array(
-            'setdefaults' => true, 'replacedefaults' => true, 'setoptional' => true, 'setrequired' => true,
-            'setallowedvalues' => true, 'addallowedvalues' => true, 'setallowedtypes' => true,
-            'addallowedtypes' => true, 'setfilters' => true
+          'setdefaults' => true, 'replacedefaults' => true, 'setoptional' => true, 'setrequired' => true,
+          'setallowedvalues' => true, 'addallowedvalues' => true, 'setallowedtypes' => true,
+          'addallowedtypes' => true, 'setfilters' => true
         );
 
         $var = $node->var;
@@ -384,10 +384,10 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
 
         if (null === $domain) {
             $this->defaultDomainMessages[] = array(
-                'id' => $id,
-                'source' => $source,
-                'desc' => $desc,
-                'meaning' => $meaning
+              'id' => $id,
+              'source' => $source,
+              'desc' => $desc,
+              'meaning' => $meaning
             );
         } else {
             $this->addToCatalogue($id, $source, $domain, $desc, $meaning);

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -182,7 +182,6 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
      * @param Node $item
      * @param $domain
      * @return bool
-     * @internal
      */
     protected function parseEmptyValueNode(Node $item, $domain)
     {
@@ -213,7 +212,6 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
      * @param Node $node
      * @param $domain
      * @return bool
-     * @internal
      */
     protected function parseChoiceNode(Node $item, Node $node, $domain)
     {
@@ -254,7 +252,6 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
      * @param Node $item
      * @param $domain
      * @return bool
-     * @internal
      */
     protected function parseAttrNode(Node $item, $domain)
     {
@@ -330,7 +327,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
      * @param $item
      * @param null $domain
      */
-    private function parseItem($item, $domain = null)
+    protected function parseItem($item, $domain = null)
     {
         // get doc comment
         $ignore = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
My forms have some extra translatable options in them (like "help_text") which are provided by MopaBootstrapBundle. I need to customise the FormExtractor::enterNode() method but because of the private methods it makes this impossible.

## Todos
- [ na ] Tests
- [ na ] Documentation
- [  done ] Changelog
