### PR TITLE
use the relative path for the reference-file

### DIFF
--- a/Translation/Extractor/File/AuthenticationMessagesExtractor.php
+++ b/Translation/Extractor/File/AuthenticationMessagesExtractor.php
@@ -194,7 +194,7 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
         $message = Message::create($node->expr->value, $this->domain)
             ->setDesc($desc)
             ->setMeaning($meaning)
-            ->addSource(new FileSource((string) $this->file, $node->expr->getLine()))
+            ->addSource(new FileSource($this->file->getRelativePathname(), $node->expr->getLine()))
         ;
 
         $this->catalogue->add($message);

--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -175,7 +175,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
         $message = new Message($id, $domain);
         $message->setDesc($desc);
         $message->setMeaning($meaning);
-        $message->addSource(new FileSource((string) $this->file, $node->getLine()));
+        $message->addSource(new FileSource($this->file->getRelativePathname(), $node->getLine()));
 
         $this->catalogue->add($message);
     }

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -379,7 +379,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
             throw new RuntimeException($message);
         }
 
-        $source = new FileSource((string) $this->file, $item->value->getLine());
+        $source = new FileSource($this->file->getRelativePathname(), $item->value->getLine());
         $id = $item->value->value;
 
         if (null === $domain) {

--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -73,7 +73,7 @@ class TwigFileExtractor implements FileVisitorInterface, \Twig_NodeVisitorInterf
             }
 
             $message = new Message($id, $domain);
-            $message->addSource(new FileSource((string) $this->file, $node->getLine()));
+            $message->addSource(new FileSource($this->file->getRelativePathname(), $node->getLine()));
             $this->catalogue->add($message);
         } elseif ($node instanceof \Twig_Node_Expression_Filter) {
             $name = $node->getNode('filter')->getAttribute('value');
@@ -102,7 +102,7 @@ class TwigFileExtractor implements FileVisitorInterface, \Twig_NodeVisitorInterf
                 }
 
                 $message = new Message($id, $domain);
-                $message->addSource(new FileSource((string) $this->file, $node->getLine()));
+                $message->addSource(new FileSource($this->file->getRelativePathname(), $node->getLine()));
 
                 for ($i=count($this->stack)-2; $i>=0; $i-=1) {
                     if (!$this->stack[$i] instanceof \Twig_Node_Expression_Filter) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | Apache2


## Description
When I dump translations in xliff format, the reference-file are full path strings.

The relative path is relevant enough to locate the files.
Developers might not use the same directory for their projects.

So I do not want having the translations always being updated switch my development environment (the projet path)

Exemple:
Currently I got

    <trans-unit id="sd5f4df5g4f5g4g" resname="Create">
            <source>Create</source>
            <target state="new">Create</target>
            <jms:reference-file line="86">/var/ww/myproject/src/AppBundle/Controller/SomeController.php</jms:reference-file>
      </trans-unit>

With the PR:

    <trans-unit id="sd5f4df5g4f5g4g" resname="Create">
            <source>Create</source>
            <target state="new">Create</target>
            <jms:reference-file line="86">AppBundle/Controller/SomeController.php</jms:reference-file>
      </trans-unit>

