### PR TITLE
Sort the sources to use alpha order in the xliff file.

### DIFF
--- a/Tests/Translation/Dumper/XliffDumperTest.php
+++ b/Tests/Translation/Dumper/XliffDumperTest.php
@@ -59,7 +59,7 @@ EOF;
 
         $catalogue = $this->getStructureCatalogue();
 
-        $this->assertEquals($this->getOutput('structure'), $dumper->dump($catalogue, 'messages'));
+        $this->assertEquals($this->getOutput('structure_full_path'), $dumper->dump($catalogue, 'messages'));
     }
 
     /**
@@ -99,8 +99,11 @@ EOF;
         $catalogue->setLocale('en');
 
         $message = new Message('foo.bar.baz');
-        $message->addSource(new FileSource('/a/b/c/foo/bar', 1, 2));
+        $message->addSource(new FileSource('/z/order/test', 1, 2));
         $message->addSource(new FileSource('bar/baz', 1, 2));
+        $message->addSource(new FileSource('bar/baz', 1, 5));
+        $message->addSource(new FileSource('/a/b/c/foo/bar', 1, 2));
+
         $catalogue->add($message);
 
         return $catalogue;

--- a/Tests/Translation/Dumper/xliff/structure_full_path.xml
+++ b/Tests/Translation/Dumper/xliff/structure_full_path.xml
@@ -9,9 +9,10 @@
       <trans-unit id="fb2d5a853a8edd799b4084a828d7d6746210534b" resname="foo.bar.baz">
         <source>foo.bar.baz</source>
         <target state="new">foo.bar.baz</target>
-        <jms:reference-file>/a/b/c/foo/bar</jms:reference-file>
-        <jms:reference-file>/z/order/test</jms:reference-file>
-        <jms:reference-file>bar/baz</jms:reference-file>
+        <jms:reference-file line="1" column="2">/a/b/c/foo/bar</jms:reference-file>
+        <jms:reference-file line="1" column="2">/z/order/test</jms:reference-file>
+        <jms:reference-file line="1" column="2">bar/baz</jms:reference-file>
+        <jms:reference-file line="1" column="5">bar/baz</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/Translation/Dumper/XliffDumper.php
+++ b/Translation/Dumper/XliffDumper.php
@@ -207,7 +207,7 @@ class XliffDumper implements DumperInterface
      */
     protected function getSortedSources($sources)
     {
-        $indexedSources = [];
+        $indexedSources = array();
         foreach ($sources as $source) {
             if ($source instanceof FileSource) {
                 $index = $source->getPath();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |  no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | 
| Fixed tickets | 
| License       | Apache2


## Description
I want to have the reference file listed in alpha order. I also wanted to avoid having twice the reference file if the referencePosition is not displayed
