### PR TITLE
Relative path

### DIFF
--- a/Model/Message.php
+++ b/Model/Message.php
@@ -73,6 +73,8 @@ class Message
      * @param $id
      * @param string $domain
      * @return Message
+     *
+     * @deprecated Will be removed in 2.0. Use the FileSourceFactory
      */
     public static function forThisFile($id, $domain = 'messages')
     {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
         <parameter key="jms_translation.twig_extension.class">JMS\TranslationBundle\Twig\TranslationExtension</parameter>
-        
+
         <parameter key="jms_translation.extractor_manager.class">JMS\TranslationBundle\Translation\ExtractorManager</parameter>
         <parameter key="jms_translation.extractor.file_extractor.class">JMS\TranslationBundle\Translation\Extractor\FileExtractor</parameter>
         <parameter key="jms_translation.extractor.file.default_php_extractor">JMS\TranslationBundle\Translation\Extractor\File\DefaultPhpFileExtractor</parameter>
@@ -15,21 +15,22 @@
         <parameter key="jms_translation.extractor.file.form_extractor.class">JMS\TranslationBundle\Translation\Extractor\File\FormExtractor</parameter>
         <parameter key="jms_translation.extractor.file.validation_extractor.class">JMS\TranslationBundle\Translation\Extractor\File\ValidationExtractor</parameter>
         <parameter key="jms_translation.extractor.file.authentication_message_extractor.class">JMS\TranslationBundle\Translation\Extractor\File\AuthenticationMessagesExtractor</parameter>
-        
+
         <parameter key="jms_translation.loader.symfony.xliff_loader.class">JMS\TranslationBundle\Translation\Loader\Symfony\XliffLoader</parameter>
         <parameter key="jms_translation.loader.xliff_loader.class">JMS\TranslationBundle\Translation\Loader\XliffLoader</parameter>
         <parameter key="jms_translation.loader.symfony_adapter.class">JMS\TranslationBundle\Translation\Loader\SymfonyLoaderAdapter</parameter>
         <parameter key="jms_translation.loader_manager.class">JMS\TranslationBundle\Translation\LoaderManager</parameter>
-        
+
         <parameter key="jms_translation.dumper.php_dumper.class">JMS\TranslationBundle\Translation\Dumper\PhpDumper</parameter>
         <parameter key="jms_translation.dumper.xliff_dumper.class">JMS\TranslationBundle\Translation\Dumper\XliffDumper</parameter>
         <parameter key="jms_translation.dumper.yaml_dumper.class">JMS\TranslationBundle\Translation\Dumper\YamlDumper</parameter>
         <parameter key="jms_translation.dumper.symfony_adapter.class">JMS\TranslationBundle\Translation\Dumper\SymfonyDumperAdapter</parameter>
-        
+
         <parameter key="jms_translation.file_writer.class">JMS\TranslationBundle\Translation\FileWriter</parameter>
-        
+
         <parameter key="jms_translation.updater.class">JMS\TranslationBundle\Translation\Updater</parameter>
         <parameter key="jms_translation.config_factory.class">JMS\TranslationBundle\Translation\ConfigFactory</parameter>
+        <parameter key="jms_translation.file_source_factory.class">JMS\TranslationBundle\Translation\FileSourceFactory</parameter>
     </parameters>
 
     <services>
@@ -39,18 +40,22 @@
             <argument type="service" id="logger" />
             <argument type="service" id="jms_translation.file_writer" />
         </service>
-        
+
         <service id="jms_translation.config_factory" class="%jms_translation.config_factory.class%" />
-        
+
+        <service id="jms_translation.file_source_factory" class="%jms_translation.file_source_factory.class%">
+            <argument>%kernel.root_dir%</argument>
+        </service>
+
         <service id="jms_translation.file_writer" class="%jms_translation.file_writer.class%" public="false" />
-        
+
         <!-- Loaders -->
         <service id="jms_translation.loader.symfony_adapter" class="%jms_translation.loader.symfony_adapter.class%" public="false" abstract="true" />
         <service id="jms_translation.loader_manager" class="%jms_translation.loader_manager.class%" /><!-- public as needed by the TranslateController -->
         <service id="jms_translation.loader.xliff_loader" class="%jms_translation.loader.xliff_loader.class%" public="false">
             <tag name="jms_translation.loader" format="xliff" />
         </service>
-        
+
         <!-- Dumpers -->
         <service id="jms_translation.dumper.php_dumper" class="%jms_translation.dumper.php_dumper.class%" public="false">
             <tag name="jms_translation.dumper" format="php" />
@@ -71,13 +76,13 @@
             <tag name="jms_translation.dumper" format="yml" />
         </service>
         <service id="jms_translation.dumper.symfony_adapter" class="%jms_translation.dumper.symfony_adapter.class%" public="false" abstract="true" />
-        
+
         <!-- Extractors -->
         <service id="jms_translation.extractor_manager" class="%jms_translation.extractor_manager.class%" public="false">
             <argument type="service" id="jms_translation.extractor.file_extractor" />
             <argument type="service" id="logger" />
         </service>
-        
+
         <!-- File-based extractors -->
         <service id="jms_translation.extractor.file_extractor" class="%jms_translation.extractor.file_extractor.class%" public="false">
             <argument type="service" id="twig" />
@@ -85,10 +90,12 @@
         </service>
         <service id="jms_translation.extractor.file.default_php_extractor" class="%jms_translation.extractor.file.default_php_extractor%" public="false">
             <argument type="service" id="jms_translation.doc_parser" />
+            <argument type="service" id="jms_translation.file_source_factory" />
             <tag name="jms_translation.file_visitor" />
         </service>
         <service id="jms_translation.extractor.file.form_extractor" class="%jms_translation.extractor.file.form_extractor.class%" public="false">
             <argument type="service" id="jms_translation.doc_parser" />
+            <argument type="service" id="jms_translation.file_source_factory" />
             <tag name="jms_translation.file_visitor" />
         </service>
         <service id="jms_translation.extractor.file.translation_container_extractor" class="%jms_translation.extractor.file.translation_container_extractor%" public="false">
@@ -96,6 +103,7 @@
         </service>
         <service id="jms_translation.extractor.file.twig_extractor" class="%jms_translation.extractor.file.twig_extractor%" public="false">
             <argument type="service" id="twig" />
+            <argument type="service" id="jms_translation.file_source_factory" />
             <tag name="jms_translation.file_visitor" />
         </service>
         <service id="jms_translation.extractor.file.validation_extractor" class="%jms_translation.extractor.file.validation_extractor.class%" public="false">
@@ -104,9 +112,10 @@
         </service>
         <service id="jms_translation.extractor.file.authentication_message_extractor" class="%jms_translation.extractor.file.authentication_message_extractor.class%" public="false">
             <argument type="service" id="jms_translation.doc_parser" />
+            <argument type="service" id="jms_translation.file_source_factory" />
             <tag name="jms_translation.file_visitor" />
         </service>
-        
+
         <!-- Util -->
         <service id="jms_translation.doc_parser" class="Doctrine\Common\Annotations\DocParser" public="false">
             <call method="setImports">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
         <parameter key="jms_translation.twig_extension.class">JMS\TranslationBundle\Twig\TranslationExtension</parameter>

--- a/Tests/Translation/Extractor/File/AuthenticationMessagesExtractorTest.php
+++ b/Tests/Translation/Extractor/File/AuthenticationMessagesExtractorTest.php
@@ -22,6 +22,7 @@ use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\File\AuthenticationMessagesExtractor;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
 
 class AuthenticationMessagesExtractorTest extends BasePhpFileExtractorTest
 {
@@ -44,6 +45,6 @@ class AuthenticationMessagesExtractorTest extends BasePhpFileExtractorTest
 
     protected function getDefaultExtractor()
     {
-        return new AuthenticationMessagesExtractor($this->getDocParser());
+        return new AuthenticationMessagesExtractor($this->getDocParser(), new FileSourceFactory('faux'));
     }
 }

--- a/Tests/Translation/Extractor/File/DefaultPhpFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/DefaultPhpFileExtractorTest.php
@@ -23,6 +23,7 @@ use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\File\DefaultPhpFileExtractor;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
 
 class DefaultPhpFileExtractorTest extends BasePhpFileExtractorTest
 {
@@ -85,6 +86,6 @@ class DefaultPhpFileExtractorTest extends BasePhpFileExtractorTest
 
     protected function getDefaultExtractor()
     {
-        return new DefaultPhpFileExtractor($this->getDocParser());
+        return new DefaultPhpFileExtractor($this->getDocParser(), new FileSourceFactory('faux'));
     }
 }

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -24,6 +24,7 @@ use JMS\TranslationBundle\Translation\Extractor\File\FormExtractor;
 use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
 use PhpParser\Lexer;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
@@ -295,7 +296,7 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
         ));
         $docParser->setIgnoreNotImportedAnnotations(true);
 
-        $this->extractor = new FormExtractor($docParser);
+        $this->extractor = new FormExtractor($docParser, new FileSourceFactory('faux'));
     }
 
     private function extract($file)

--- a/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
@@ -18,6 +18,7 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Extractor\File;
 
+use JMS\TranslationBundle\Translation\FileSourceFactory;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Component\Routing\RequestContext;
@@ -158,7 +159,7 @@ class TwigFileExtractorTest extends \PHPUnit_Framework_TestCase
         }
 
         if (null === $extractor) {
-            $extractor = new TwigFileExtractor($env);
+            $extractor = new TwigFileExtractor($env, new FileSourceFactory('faux'));
         }
 
         $ast = $env->parse($env->tokenize(file_get_contents($file), $file));

--- a/Tests/Translation/Extractor/FileExtractorTest.php
+++ b/Tests/Translation/Extractor/FileExtractorTest.php
@@ -18,6 +18,7 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Extractor;
 
+use JMS\TranslationBundle\Translation\FileSourceFactory;
 use Psr\Log\NullLogger;
 use Doctrine\Common\Annotations\DocParser;
 use JMS\TranslationBundle\Translation\Extractor\File\FormExtractor;
@@ -110,12 +111,14 @@ class FileExtractorTest extends \PHPUnit_Framework_TestCase
 
         $factory = new $metadataFactoryClass(new AnnotationLoader(new AnnotationReader()));
 
+        $dummyFileSourceFactory = new FileSourceFactory('faux');
+
         $extractor = new FileExtractor($twig, new NullLogger(), array(
-            new DefaultPhpFileExtractor($docParser),
+            new DefaultPhpFileExtractor($docParser, $dummyFileSourceFactory),
             new TranslationContainerExtractor(),
-            new TwigFileExtractor($twig),
+            new TwigFileExtractor($twig, $dummyFileSourceFactory),
             new ValidationExtractor($factory),
-            new FormExtractor($docParser),
+            new FormExtractor($docParser, $dummyFileSourceFactory),
         ));
         $extractor->setDirectory($directory);
 

--- a/Translation/Extractor/File/AuthenticationMessagesExtractor.php
+++ b/Translation/Extractor/File/AuthenticationMessagesExtractor.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -19,7 +18,6 @@
 namespace JMS\TranslationBundle\Translation\Extractor\File;
 
 use JMS\TranslationBundle\Exception\RuntimeException;
-use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Annotation\Meaning;
 use JMS\TranslationBundle\Annotation\Desc;
@@ -28,6 +26,7 @@ use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use Doctrine\Common\Annotations\DocParser;
 use JMS\TranslationBundle\Logger\LoggerAwareInterface;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
@@ -35,6 +34,11 @@ use Psr\Log\LoggerInterface;
 
 class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisitorInterface, NodeVisitor
 {
+    /**
+     * @var FileSourceFactory
+     */
+    private $fileSourceFactory;
+
     /**
      * @var string
      */
@@ -83,10 +87,12 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
     /**
      * AuthenticationMessagesExtractor constructor.
      * @param DocParser $parser
+     * @param FileSourceFactory $fileSourceFactory
      */
-    public function __construct(DocParser $parser)
+    public function __construct(DocParser $parser, FileSourceFactory $fileSourceFactory)
     {
         $this->docParser = $parser;
+        $this->fileSourceFactory = $fileSourceFactory;
         $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor($this);
     }
@@ -192,7 +198,7 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
         $message = Message::create($node->expr->value, $this->domain)
             ->setDesc($desc)
             ->setMeaning($meaning)
-            ->addSource(new FileSource((string) $this->file, $node->expr->getLine()))
+            ->addSource($this->fileSourceFactory->create((string) $this->file, $node->expr->getLine()))
         ;
 
         $this->catalogue->add($message);

--- a/Translation/Extractor/File/AuthenticationMessagesExtractor.php
+++ b/Translation/Extractor/File/AuthenticationMessagesExtractor.php
@@ -199,7 +199,7 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
         $message = Message::create($node->expr->value, $this->domain)
             ->setDesc($desc)
             ->setMeaning($meaning)
-            ->addSource($this->fileSourceFactory->create((string) $this->file, $node->expr->getLine()))
+            ->addSource($this->fileSourceFactory->create($this->file, $node->expr->getLine()))
         ;
 
         $this->catalogue->add($message);

--- a/Translation/Extractor/File/AuthenticationMessagesExtractor.php
+++ b/Translation/Extractor/File/AuthenticationMessagesExtractor.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -172,7 +172,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
         $message = new Message($id, $domain);
         $message->setDesc($desc);
         $message->setMeaning($meaning);
-        $message->addSource($this->fileSourceFactory->create((string) $this->file, $node->getLine()));
+        $message->addSource($this->fileSourceFactory->create($this->file, $node->getLine()));
         $this->catalogue->add($message);
     }
 

--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -48,6 +48,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
      * @var FileSourceFactory
      */
     private $fileSourceFactory;
+    
     /**
      * @var NodeTraverser
      */

--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -20,7 +20,6 @@ namespace JMS\TranslationBundle\Translation\Extractor\File;
 
 use JMS\TranslationBundle\Exception\RuntimeException;
 use Doctrine\Common\Annotations\DocParser;
-use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Annotation\Meaning;
 use JMS\TranslationBundle\Annotation\Desc;
@@ -28,6 +27,7 @@ use JMS\TranslationBundle\Annotation\Ignore;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Logger\LoggerAwareInterface;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
@@ -44,6 +44,10 @@ use Psr\Log\LoggerInterface;
  */
 class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterface, NodeVisitor
 {
+    /**
+     * @var FileSourceFactory
+     */
+    private $fileSourceFactory;
     /**
      * @var NodeTraverser
      */
@@ -77,10 +81,12 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
     /**
      * DefaultPhpFileExtractor constructor.
      * @param DocParser $docParser
+     * @param FileSourceFactory $fileSourceFactory
      */
-    public function __construct(DocParser $docParser)
+    public function __construct(DocParser $docParser, FileSourceFactory $fileSourceFactory)
     {
         $this->docParser = $docParser;
+        $this->fileSourceFactory = $fileSourceFactory;
         $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor($this);
     }
@@ -165,8 +171,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
         $message = new Message($id, $domain);
         $message->setDesc($desc);
         $message->setMeaning($meaning);
-        $message->addSource(new FileSource((string) $this->file, $node->getLine()));
-
+        $message->addSource($this->fileSourceFactory->create((string) $this->file, $node->getLine()));
         $this->catalogue->add($message);
     }
 

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -41,6 +41,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
      * @var FileSourceFactory
      */
     private $fileSourceFactory;
+    
     /**
      * @var DocParser
      */

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -19,7 +19,6 @@
 namespace JMS\TranslationBundle\Translation\Extractor\File;
 
 use JMS\TranslationBundle\Exception\RuntimeException;
-use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Annotation\Meaning;
 use JMS\TranslationBundle\Annotation\Desc;
@@ -28,6 +27,7 @@ use Doctrine\Common\Annotations\DocParser;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use JMS\TranslationBundle\Logger\LoggerAwareInterface;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
@@ -37,6 +37,10 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeVisitor
 {
+    /**
+     * @var FileSourceFactory
+     */
+    private $fileSourceFactory;
     /**
      * @var DocParser
      */
@@ -75,11 +79,12 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
     /**
      * FormExtractor constructor.
      * @param DocParser $docParser
+     * @param FileSourceFactory $fileSourceFactory
      */
-    public function __construct(DocParser $docParser)
+    public function __construct(DocParser $docParser, FileSourceFactory $fileSourceFactory)
     {
         $this->docParser = $docParser;
-
+        $this->fileSourceFactory = $fileSourceFactory;
         $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor($this);
     }
@@ -379,7 +384,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
             throw new RuntimeException($message);
         }
 
-        $source = new FileSource((string) $this->file, $item->value->getLine());
+        $source = $this->fileSourceFactory->create((string) $this->file, $item->value->getLine());
         $id = $item->value->value;
 
         if (null === $domain) {

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -53,7 +53,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
     private $traverser;
 
     /**
-     * @var string
+     * @var \SplFileInfo
      */
     private $file;
 
@@ -385,7 +385,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
             throw new RuntimeException($message);
         }
 
-        $source = $this->fileSourceFactory->create((string) $this->file, $item->value->getLine());
+        $source = $this->fileSourceFactory->create($this->file, $item->value->getLine());
         $id = $item->value->value;
 
         if (null === $domain) {

--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -80,7 +80,7 @@ class TwigFileExtractor implements FileVisitorInterface, \Twig_NodeVisitorInterf
             }
 
             $message = new Message($id, $domain);
-            $message->addSource($this->fileSourceFactory->create((string) $this->file, $node->getLine()));
+            $message->addSource($this->fileSourceFactory->create($this->file, $node->getLine()));
             $this->catalogue->add($message);
         } elseif ($node instanceof \Twig_Node_Expression_Filter) {
             $name = $node->getNode('filter')->getAttribute('value');
@@ -109,7 +109,7 @@ class TwigFileExtractor implements FileVisitorInterface, \Twig_NodeVisitorInterf
                 }
 
                 $message = new Message($id, $domain);
-                $message->addSource($this->fileSourceFactory->create((string) $this->file, $node->getLine()));
+                $message->addSource($this->fileSourceFactory->create($this->file, $node->getLine()));
 
                 for ($i=count($this->stack)-2; $i>=0; $i-=1) {
                     if (!$this->stack[$i] instanceof \Twig_Node_Expression_Filter) {

--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -19,14 +19,19 @@
 namespace JMS\TranslationBundle\Translation\Extractor\File;
 
 use JMS\TranslationBundle\Exception\RuntimeException;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
 use Symfony\Bridge\Twig\Node\TransNode;
-use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 
 class TwigFileExtractor implements FileVisitorInterface, \Twig_NodeVisitorInterface
 {
+    /**
+     * @var FileSourceFactory
+     */
+    private $fileSourceFactory;
+
     /**
      * @var \SplFileInfo
      */
@@ -50,9 +55,11 @@ class TwigFileExtractor implements FileVisitorInterface, \Twig_NodeVisitorInterf
     /**
      * TwigFileExtractor constructor.
      * @param \Twig_Environment $env
+     * @param FileSourceFactory $fileSourceFactory
      */
-    public function __construct(\Twig_Environment $env)
+    public function __construct(\Twig_Environment $env, FileSourceFactory $fileSourceFactory)
     {
+        $this->fileSourceFactory = $fileSourceFactory;
         $this->traverser = new \Twig_NodeTraverser($env, array($this));
     }
 
@@ -73,7 +80,7 @@ class TwigFileExtractor implements FileVisitorInterface, \Twig_NodeVisitorInterf
             }
 
             $message = new Message($id, $domain);
-            $message->addSource(new FileSource((string) $this->file, $node->getLine()));
+            $message->addSource($this->fileSourceFactory->create((string) $this->file, $node->getLine()));
             $this->catalogue->add($message);
         } elseif ($node instanceof \Twig_Node_Expression_Filter) {
             $name = $node->getNode('filter')->getAttribute('value');
@@ -102,7 +109,7 @@ class TwigFileExtractor implements FileVisitorInterface, \Twig_NodeVisitorInterf
                 }
 
                 $message = new Message($id, $domain);
-                $message->addSource(new FileSource((string) $this->file, $node->getLine()));
+                $message->addSource($this->fileSourceFactory->create((string) $this->file, $node->getLine()));
 
                 for ($i=count($this->stack)-2; $i>=0; $i-=1) {
                     if (!$this->stack[$i] instanceof \Twig_Node_Expression_Filter) {

--- a/Translation/FileSourceFactory.php
+++ b/Translation/FileSourceFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\TranslationBundle\Translation;
+
+use JMS\TranslationBundle\Model\FileSource;
+
+class FileSourceFactory
+{
+    /**
+     * @var string
+     */
+    protected $kernelRoot;
+
+    /**
+     * FileSourceFactory constructor.
+     * @param string $kernelRoot
+     */
+    public function __construct($kernelRoot)
+    {
+        $this->kernelRoot = $kernelRoot;
+    }
+
+    /**
+     * Generate a new FileSource with a relative path
+     * @param          $path string
+     * @param null|int $line
+     * @param null|int $column
+     * @return FileSource
+     */
+    public function create($path, $line = null, $column = null)
+    {
+        if (0 === strpos($path, $this->kernelRoot)) {
+            $path = substr($path, strlen($this->kernelRoot));
+        }
+        $path = str_replace($this->kernelRoot, '', $path);
+
+        return new FileSource($path, $line, $column);
+    }
+}

--- a/Translation/FileSourceFactory.php
+++ b/Translation/FileSourceFactory.php
@@ -29,6 +29,7 @@ class FileSourceFactory
 
     /**
      * FileSourceFactory constructor.
+     *
      * @param string $kernelRoot
      */
     public function __construct($kernelRoot)
@@ -37,14 +38,17 @@ class FileSourceFactory
     }
 
     /**
-     * Generate a new FileSource with a relative path
-     * @param          $path string
-     * @param null|int $line
-     * @param null|int $column
+     * Generate a new FileSource with a relative path.
+     *
+     * @param \SplFileInfo $path   string
+     * @param null|int     $line
+     * @param null|int     $column
+     *
      * @return FileSource
      */
-    public function create($path, $line = null, $column = null)
+    public function create(\SplFileInfo $file, $line = null, $column = null)
     {
+        $path = (string) $file;
         if (0 === strpos($path, $this->kernelRoot)) {
             $path = substr($path, strlen($this->kernelRoot));
         }

--- a/Translation/FileSourceFactory.php
+++ b/Translation/FileSourceFactory.php
@@ -48,7 +48,6 @@ class FileSourceFactory
         if (0 === strpos($path, $this->kernelRoot)) {
             $path = substr($path, strlen($this->kernelRoot));
         }
-        $path = str_replace($this->kernelRoot, '', $path);
 
         return new FileSource($path, $line, $column);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | Fixes #366, Replaces #358 and #378
| License       | Apache2


## Description
This PR makes sure the path is relative the `kernel.root_dir`

Before: 
```xml
<trans-unit id="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" resname="foo">
        <source>foo</source>
        <target>adsa</target>
        <jms:reference-file line="16">/User/tobias/Workpalce/SymfonyBundle/src/AppBundle/Controller/DefaultController.php</jms:reference-file>
      </trans-unit>
```


After: 
```xml
<trans-unit id="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" resname="foo">
        <source>foo</source>
        <target>adsa</target>
        <jms:reference-file line="16">/../src/AppBundle/Controller/DefaultController.php</jms:reference-file>
      </trans-unit>
```

This PR builds on @ABM-Dan work. 