### PR TITLE
Make sure Message id is always a string

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,15 +1,26 @@
 # Changelog
 
+### 1.3.0 to UNRELEASED
 
-### 1.2.2 to next release
+### 1.2.3 to 1.3.0
+
+* XliffMessage is improved with note elements and attributes. 
+* Keeping new lines inside translations
+* Fix global namespace extraction.
+* Better documentation
+* Clearer Exception messages
+* The `DefaultPhpFileExtractor` could be extended an modified which function we should extraction messages from.
+* Make sure Message ID is always a string to avoid issues with numerial IDs. 
+
+### 1.2.2 to 1.2.3
 
 * Support for placeholders and empty_value.
-* Slightly easier webui extension with new extensible js class
+* Slightly easier WebUI extension with new extensible js class
 * Extracted strings have the full source path stored
 * Improvements to WebUI logic
 * Various extraction bug fixes (attr as variable)
 * Various improvements to xliff dumper
-* Ensure full symfony 3.0 support and tests
+* Ensure full Symfony 3.0 support and tests
 
 ### 1.2.1 to 1.2.2
 

--- a/Model/Message.php
+++ b/Model/Message.php
@@ -106,12 +106,12 @@ class Message
     }
 
     /**
-     * @param $id
+     * @param string $id
      * @param string $domain
      */
     public function __construct($id, $domain = 'messages')
     {
-        $this->id = $id;
+        $this->id = (string) $id;
         $this->domain = $domain;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #249, #83
| License       | Apache2


## Description
Just make sure Message id is always a string. 
