### PR TITLE
Making source file clickable in WebUI

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 * Clearer Exception messages
 * The `DefaultPhpFileExtractor` could be extended an modified which function we should extraction messages from.
 * Make sure Message ID is always a string to avoid issues with numerial IDs. 
+* Make source files clickable in WebUI
 
 ### 1.2.2 to 1.2.3
 

--- a/Resources/views/Translate/messages.html.twig
+++ b/Resources/views/Translate/messages.html.twig
@@ -34,7 +34,10 @@
                         <h6>Sources</h6>
                         <ul>
                         {% for source in message.sources %}
-                            <li title="{{ source }}" class="jms-sources-list-item truncate-left">{{ source }}</li>
+                            {%- set link = source.path|file_link(source.line) %}
+                            {%- if link %}<a href="{{ link }}" title="{{ source }}">{% else %}<span>{% endif %}
+                                <li class="jms-sources-list-item truncate-left">{{ source }}</li>
+                            {%- if link %}</a>{% else %}</span>{% endif %}
                         {% endfor %}
                         </ul>
                     {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Fixes #110
| License       | Apache2


## Description
Make sure you can click the file in the WebUI to get to the source code. 

