### PR TITLE
Update PHP Parser version for compatability with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,6 @@ matrix:
         - php: 7.1
           env: SYMFONY_VERSION=3.*
 
-before_script:
-    - phpenv config-add travis.php.ini
-
 before_install:
     - travis_retry composer self-update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ cache:
         - $HOME/.composer/cache
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 env:
@@ -26,14 +25,21 @@ matrix:
         - php: hhvm
 
     include:
-        - php: 5.3
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_VERSION=2.3.* COVERAGE=true TEST_COMMAND="phpunit --coverage-text --coverage-clover=build/coverage.xml"
+#        - php: 5.3
+#          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_VERSION=2.3.* COVERAGE=true TEST_COMMAND="phpunit --coverage-text --coverage-clover=build/coverage.xml"
         - php: 5.6
           env: SYMFONY_VERSION=2.3.*
         - php: 5.6
           env: SYMFONY_VERSION=2.7.*
         - php: 5.6
           env: SYMFONY_VERSION=3.0.*
+        - php: 7.0
+          env: SYMFONY_VERSION=3.*
+        - php: 7.1
+          env: SYMFONY_VERSION=3.*
+
+before_script:
+    - phpenv config-add travis.php.ini
 
 before_install:
     - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -1,42 +1,54 @@
 {
-    "name":         "jms/translation-bundle",
-    "description":  "Puts the Symfony Translation Component on steroids",
-    "keywords":     ["translation", "multilanguage", "extract", "webinterface", "ui", "i18n", "extraction", "interface"],
-    "homepage":     "http://jmsyst.com/bundles/JMSTranslationBundle",
-    "type":         "symfony-bundle",
-    "license":      "Apache2",
-    "authors": [
-        {
-            "name":   "Johannes M. Schmitt",
-            "email":  "schmittjoh@gmail.com"
-        }
-    ],
-    "minimum-stability": "stable",
-    "require": {
-        "php": "^5.3.3|^7.0",
-        "symfony/framework-bundle": "^2.3|^3.0",
-        "nikic/php-parser": "^1.4|^2.0",
-        "symfony/console": "^2.3|^3.0"
-    },
-    "conflict": {
-        "twig/twig": "<1.12"
-    },
-    "require-dev": {
-        "psr/log": "^1.0",
-        "twig/twig": "^1.12",
-        "symfony/symfony": "^2.3|^3.0",
-        "symfony/expression-language": "~2.6|~3.0",
-        "sensio/framework-extra-bundle": "^2.3|^3.0",
-        "jms/di-extra-bundle": "^1.1",
-        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6"
-    },
-    "autoload": {
-        "psr-0": { "JMS\\TranslationBundle": "" }
-    },
-    "target-dir": "JMS/TranslationBundle",
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.3-dev"
-        }
+  "name": "jms/translation-bundle",
+  "description": "Puts the Symfony Translation Component on steroids",
+  "keywords": [
+    "translation",
+    "multilanguage",
+    "extract",
+    "webinterface",
+    "ui",
+    "i18n",
+    "extraction",
+    "interface"
+  ],
+  "homepage": "http://jmsyst.com/bundles/JMSTranslationBundle",
+  "type": "symfony-bundle",
+  "license": "Apache2",
+  "authors": [
+    {
+      "name": "Johannes M. Schmitt",
+      "email": "schmittjoh@gmail.com"
     }
+  ],
+  "minimum-stability": "dev",
+  "prefer-stable":true,
+  "require": {
+    "php": "^5.5|^7.0|^7.1",
+    "symfony/framework-bundle": "^2.3|^3.0|^3.1",
+    "nikic/php-parser": "^3.0",
+    "symfony/console": "^2.3|^3.0"
+  },
+  "conflict": {
+    "twig/twig": "<1.12"
+  },
+  "require-dev": {
+    "psr/log": "^1.0",
+    "twig/twig": "^1.12",
+    "symfony/symfony": "^2.3|^3.0|^3.1",
+    "symfony/expression-language": "~2.6|~3.0",
+    "sensio/framework-extra-bundle": "^2.3|^3.0",
+    "jms/di-extra-bundle": "^1.1",
+    "matthiasnoback/symfony-dependency-injection-test": "^0.7.6"
+  },
+  "autoload": {
+    "psr-0": {
+      "JMS\\TranslationBundle": ""
+    }
+  },
+  "target-dir": "JMS/TranslationBundle",
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.3-dev"
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,54 +1,43 @@
 {
-  "name": "jms/translation-bundle",
-  "description": "Puts the Symfony Translation Component on steroids",
-  "keywords": [
-    "translation",
-    "multilanguage",
-    "extract",
-    "webinterface",
-    "ui",
-    "i18n",
-    "extraction",
-    "interface"
-  ],
-  "homepage": "http://jmsyst.com/bundles/JMSTranslationBundle",
-  "type": "symfony-bundle",
-  "license": "Apache2",
-  "authors": [
-    {
-      "name": "Johannes M. Schmitt",
-      "email": "schmittjoh@gmail.com"
+    "name":         "jms/translation-bundle",
+    "description":  "Puts the Symfony Translation Component on steroids",
+    "keywords":     ["translation", "multilanguage", "extract", "webinterface", "ui", "i18n", "extraction", "interface"],
+    "homepage":     "http://jmsyst.com/bundles/JMSTranslationBundle",
+    "type":         "symfony-bundle",
+    "license":      "Apache2",
+    "authors": [
+        {
+            "name":   "Johannes M. Schmitt",
+            "email":  "schmittjoh@gmail.com"
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require": {
+        "php": "^5.5|^7.0|^7.1",
+        "symfony/framework-bundle": "^2.3|^3.0|^3.1",
+        "nikic/php-parser": "^3.0",
+        "symfony/console": "^2.3|^3.0"
+    },
+    "conflict": {
+        "twig/twig": "<1.12"
+    },
+    "require-dev": {
+        "psr/log": "^1.0",
+        "twig/twig": "^1.12",
+        "symfony/symfony": "^2.3|^3.0|^3.1",
+        "symfony/expression-language": "~2.6|~3.0",
+        "sensio/framework-extra-bundle": "^2.3|^3.0",
+        "jms/di-extra-bundle": "^1.1",
+        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6"
+    },
+    "autoload": {
+        "psr-0": { "JMS\\TranslationBundle": "" }
+    },
+    "target-dir": "JMS/TranslationBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.3-dev"
+        }
     }
-  ],
-  "minimum-stability": "dev",
-  "prefer-stable":true,
-  "require": {
-    "php": "^5.5|^7.0|^7.1",
-    "symfony/framework-bundle": "^2.3|^3.0|^3.1",
-    "nikic/php-parser": "^3.0",
-    "symfony/console": "^2.3|^3.0"
-  },
-  "conflict": {
-    "twig/twig": "<1.12"
-  },
-  "require-dev": {
-    "psr/log": "^1.0",
-    "twig/twig": "^1.12",
-    "symfony/symfony": "^2.3|^3.0|^3.1",
-    "symfony/expression-language": "~2.6|~3.0",
-    "sensio/framework-extra-bundle": "^2.3|^3.0",
-    "jms/di-extra-bundle": "^1.1",
-    "matthiasnoback/symfony-dependency-injection-test": "^0.7.6"
-  },
-  "autoload": {
-    "psr-0": {
-      "JMS\\TranslationBundle": ""
-    }
-  },
-  "target-dir": "JMS/TranslationBundle",
-  "extra": {
-    "branch-alias": {
-      "dev-master": "1.3-dev"
-    }
-  }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #381 |
| License | Apache2 |
## Description

Updated composer to set PHP Parser version to current version ^3.0.
Needed to remove minimum version for PHP 5.3.3 and set minimum PHP version to 5.5. This allowed remove travis tests for lesser version.

I hope this is enough and good, in other ways, I try update it.
## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog
