### PR TITLE
Fixed relative path calculation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ php:
 
 env:
     global:
-        - TEST_COMMAND="phpunit"
+        - TEST_COMMAND="./vendor/bin/phpunit"
     matrix:
         - SYMFONY_VERSION=2.8.*
 
@@ -27,7 +27,7 @@ matrix:
 
     include:
         - php: 5.3
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_VERSION=2.3.* COVERAGE=true TEST_COMMAND="phpunit --coverage-text --coverage-clover=build/coverage.xml"
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_VERSION=2.3.0 COVERAGE=true TEST_COMMAND="./vendor/bin/phpunit --coverage-text --coverage-clover=build/coverage.xml"
         - php: 5.6
           env: SYMFONY_VERSION=2.3.*
         - php: 5.6

--- a/Tests/Translation/Extractor/File/AuthenticationMessagesExtractorTest.php
+++ b/Tests/Translation/Extractor/File/AuthenticationMessagesExtractorTest.php
@@ -18,11 +18,9 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Extractor\File;
 
-use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\File\AuthenticationMessagesExtractor;
-use JMS\TranslationBundle\Translation\FileSourceFactory;
 
 class AuthenticationMessagesExtractorTest extends BasePhpFileExtractorTest
 {
@@ -30,14 +28,17 @@ class AuthenticationMessagesExtractorTest extends BasePhpFileExtractorTest
     {
         $expected = new MessageCatalogue();
 
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyAuthException.php');
+
         $message = new Message('security.authentication_error.foo', 'authentication');
         $message->setDesc('%foo% is invalid.');
-        $message->addSource(new FileSource(__DIR__.'/Fixture/MyAuthException.php', 31));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 31));
         $expected->add($message);
 
         $message = new Message('security.authentication_error.bar', 'authentication');
         $message->setDesc('An authentication error occurred.');
-        $message->addSource(new FileSource(__DIR__.'/Fixture/MyAuthException.php', 35));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 35));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('MyAuthException.php'));
@@ -45,6 +46,6 @@ class AuthenticationMessagesExtractorTest extends BasePhpFileExtractorTest
 
     protected function getDefaultExtractor()
     {
-        return new AuthenticationMessagesExtractor($this->getDocParser(), new FileSourceFactory('faux'));
+        return new AuthenticationMessagesExtractor($this->getDocParser(), $this->getFileSourceFactory());
     }
 }

--- a/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
@@ -21,6 +21,7 @@ namespace JMS\TranslationBundle\Tests\Translation\Extractor\File;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use Doctrine\Common\Annotations\DocParser;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
 use PhpParser\Lexer;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
@@ -67,5 +68,10 @@ abstract class BasePhpFileExtractorTest extends \PHPUnit_Framework_TestCase
         $docParser->setIgnoreNotImportedAnnotations(true);
 
         return $docParser;
+    }
+
+    protected function getFileSourceFactory()
+    {
+        return new FileSourceFactory('faux');
     }
 }

--- a/Tests/Translation/Extractor/File/DefaultPhpFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/DefaultPhpFileExtractorTest.php
@@ -18,12 +18,9 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Extractor\File;
 
-use JMS\TranslationBundle\Exception\RuntimeException;
-use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\File\DefaultPhpFileExtractor;
-use JMS\TranslationBundle\Translation\FileSourceFactory;
 
 class DefaultPhpFileExtractorTest extends BasePhpFileExtractorTest
 {
@@ -31,37 +28,38 @@ class DefaultPhpFileExtractorTest extends BasePhpFileExtractorTest
     {
         $catalogue = $this->extract('Controller.php');
 
-        $path = __DIR__.'/Fixture/Controller.php';
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/Controller.php');
 
         $expected = new MessageCatalogue();
 
         $message = new Message('text.foo_bar');
         $message->setDesc('Foo bar');
-        $message->addSource(new FileSource($path, 45));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 45));
         $expected->add($message);
 
         $message = new Message('text.sign_up_successful');
         $message->setDesc('Welcome %name%! Thanks for signing up.');
-        $message->addSource(new FileSource($path, 52));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 52));
         $expected->add($message);
 
         $message = new Message('button.archive');
         $message->setDesc('Archive Message');
         $message->setMeaning('The verb (to archive), describes an action');
-        $message->addSource(new FileSource($path, 59));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 59));
         $expected->add($message);
 
         $message = new Message('text.irrelevant_doc_comment', 'baz');
-        $message->addSource(new FileSource($path, 71));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 71));
         $expected->add($message);
 
         $message = new Message('text.array_method_call');
-        $message->addSource(new FileSource($path, 76));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 76));
         $expected->add($message);
 
         $message = new Message('text.var.assign');
         $message->setDesc('The var %foo% should be assigned.');
-        $message->addSource(new FileSource($path, 82));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 82));
         $expected->add($message);
 
         $this->assertEquals($expected, $catalogue);
@@ -70,15 +68,16 @@ class DefaultPhpFileExtractorTest extends BasePhpFileExtractorTest
     public function testExtractTemplate()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/template.html.php';
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/template.html.php');
 
         $message = new Message('foo.bar');
-        $message->addSource(new FileSource($path, 1));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 1));
         $expected->add($message);
 
         $message = new Message('baz', 'moo');
         $message->setDesc('Foo Bar');
-        $message->addSource(new FileSource($path, 3));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 3));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('template.html.php'));
@@ -86,6 +85,6 @@ class DefaultPhpFileExtractorTest extends BasePhpFileExtractorTest
 
     protected function getDefaultExtractor()
     {
-        return new DefaultPhpFileExtractor($this->getDocParser(), new FileSourceFactory('faux'));
+        return new DefaultPhpFileExtractor($this->getDocParser(), $fileSourceFactory = $this->getFileSourceFactory());
     }
 }

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -18,55 +18,44 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Extractor\File;
 
-use JMS\TranslationBundle\Exception\RuntimeException;
-use Doctrine\Common\Annotations\DocParser;
 use JMS\TranslationBundle\Translation\Extractor\File\FormExtractor;
-use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
-use JMS\TranslationBundle\Translation\FileSourceFactory;
-use PhpParser\Lexer;
-use PhpParser\Parser;
-use PhpParser\ParserFactory;
 use Symfony\Component\HttpKernel\Kernel;
 
-class FormExtractorTest extends \PHPUnit_Framework_TestCase
+class FormExtractorTest extends BasePhpFileExtractorTest
 {
-    /**
-     * @var FormExtractor
-     */
-    private $extractor;
-
     /**
      * @group placeholder
      */
     public function testPlaceholderExtract()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/MyPlaceholderFormType.php';
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyPlaceholderFormType.php');
 
         $message = new Message('field.with.placeholder');
-        $message->addSource(new FileSource($path, 29));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 29));
         $expected->add($message);
 
         $message = new Message('form.placeholder.text');
         $message->setDesc('Field with a placeholder value');
-        $message->addSource(new FileSource($path, 30));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 30));
         $expected->add($message);
 
         $message = new Message('form.placeholder.text.but.no.label');
         $message->setDesc('Field with a placeholder but no label');
-        $message->addSource(new FileSource($path, 34));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 34));
         $expected->add($message);
 
         $message = new Message('form.choice_placeholder');
         $message->setDesc('Choice field with a placeholder');
-        $message->addSource(new FileSource($path, 37));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 37));
         $expected->add($message);
 
         $message = new Message('form.choice_empty_value');
         $message->setDesc('Choice field with an empty_value');
-        $message->addSource(new FileSource($path, 40));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 40));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('MyPlaceholderFormType.php'));
@@ -78,7 +67,8 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
     public function testExtract()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/MyFormType.php';
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyFormType.php');
 
         // Symfony >= 3.0 switch the default behavior of the choice field following a BC break introduced in 2.7
         // @see https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md#choices_as_values
@@ -87,83 +77,83 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
         } else {
             $message = new Message('bar');
         }
-        $message->addSource(new FileSource($path, 36));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 36));
         $expected->add($message);
 
         $message = new Message('form.states.empty_value');
         $message->setDesc('Please select a state');
-        $message->addSource(new FileSource($path, 37));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 37));
         $expected->add($message);
 
         $message = new Message('form.label.lastname');
         $message->setDesc('Lastname');
-        $message->addSource(new FileSource($path, 33));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 33));
         $expected->add($message);
 
         $message = new Message('form.label.firstname');
-        $message->addSource(new FileSource($path, 30));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 30));
         $expected->add($message);
 
         $message = new Message('form.label.password');
-        $message->addSource(new FileSource($path, 42));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 42));
         $expected->add($message);
 
         $message = new Message('form.label.password_repeated');
         $message->setDesc('Repeat password');
-        $message->addSource(new FileSource($path, 45));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 45));
         $expected->add($message);
 
         $message = new Message('form.label.street', 'address');
         $message->setDesc('Street');
-        $message->addSource(new FileSource($path, 50));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 50));
         $expected->add($message);
 
         $message = new Message('form.label.zip', 'address');
         $message->setDesc('ZIP');
-        $message->addSource(new FileSource($path, 55));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 55));
         $expected->add($message);
 
         $message = new Message('form.error.password_mismatch', 'validators');
         $message->setDesc('The entered passwords do not match');
-        $message->addSource(new FileSource($path, 47));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 47));
         $expected->add($message);
 
         $message = new Message('form.label.created');
-        $message->addSource(new FileSource($path, 75));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 75));
         $expected->add($message);
 
         $message = new Message('field.with.placeholder');
-        $message->addSource(new FileSource($path, 59));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 59));
         $expected->add($message);
 
         $message = new Message('form.placeholder.text');
         $message->setDesc('Field with a placeholder value');
-        $message->addSource(new FileSource($path, 60));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 60));
         $expected->add($message);
 
         $message = new Message('form.placeholder.text.but.no.label');
         $message->setDesc('Field with a placeholder but no label');
-        $message->addSource(new FileSource($path, 64));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 64));
         $expected->add($message);
 
         $message = new Message('form.dueDate.empty.year');
-        $message->addSource(new FileSource($path, 79));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 79));
         $expected->add($message);
 
         $message = new Message('form.dueDate.empty.month');
-        $message->addSource(new FileSource($path, 79));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 79));
         $expected->add($message);
 
         $message = new Message('form.dueDate.empty.day');
-        $message->addSource(new FileSource($path, 79));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 79));
         $expected->add($message);
 
         $message = new Message('form.choice.choice_as_values.label.foo');
-        $message->addSource(new FileSource($path, 68));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 68));
         $expected->add($message);
 
         $message = new Message('form.choice.choice_as_values.label.bar');
-        $message->addSource(new FileSource($path, 69));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 69));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('MyFormType.php'));
@@ -176,7 +166,8 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
     public function testExtractWithInterface()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/MyFormTypeWithInterface.php';
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyFormTypeWithInterface.php');
 
         // Symfony >= 3.0 switch the default behavior of the choice field following a BC break introduced in 2.7
         // @see https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md#choices_as_values
@@ -185,21 +176,21 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
         } else {
             $message = new Message('bar');
         }
-        $message->addSource(new FileSource($path, 36));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 36));
         $expected->add($message);
 
         $message = new Message('form.states.empty_value');
         $message->setDesc('Please select a state');
-        $message->addSource(new FileSource($path, 37));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 37));
         $expected->add($message);
 
         $message = new Message('form.label.lastname');
         $message->setDesc('Lastname');
-        $message->addSource(new FileSource($path, 33));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 33));
         $expected->add($message);
 
         $message = new Message('form.label.firstname');
-        $message->addSource(new FileSource($path, 30));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 30));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('MyFormTypeWithInterface.php'));
@@ -212,20 +203,21 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
     public function testExtractWithDefaultDomain()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/MyFormTypeWithDefaultDomain.php';
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyFormTypeWithDefaultDomain.php');
 
         $message = new Message('form.label.lastname', 'person');
         $message->setDesc('Lastname');
-        $message->addSource(new FileSource($path, 34));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 34));
         $expected->add($message);
 
         $message = new Message('form.label.firstname', 'person');
-        $message->addSource(new FileSource($path, 31));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 31));
         $expected->add($message);
 
         $message = new Message('form.label.street', 'address');
         $message->setDesc('Street');
-        $message->addSource(new FileSource($path, 37));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 37));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('MyFormTypeWithDefaultDomain.php'));
@@ -238,35 +230,36 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
     public function testExtractWithWithSubscriberAndListener()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/MyFormTypeWithSubscriberAndListener.php';
-        $pathSubscriber = __DIR__.'/Fixture/MyFormSubscriber.php';
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyFormTypeWithSubscriberAndListener.php');
+        $subscriberFixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyFormSubscriber.php');
 
         $message = new Message('form.label.lastname');
         $message->setDesc('Lastname');
-        $message->addSource(new FileSource($path, 36));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 36));
         $expected->add($message);
 
         $message = new Message('form.label.firstname');
-        $message->addSource(new FileSource($path, 33));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 33));
         $expected->add($message);
 
         $message = new Message('form.label.password');
-        $message->addSource(new FileSource($pathSubscriber, 37));
+        $message->addSource($fileSourceFactory->create($subscriberFixtureSplInfo, 37));
         $expected->add($message);
 
         $message = new Message('form.label.password_repeated');
         $message->setDesc('Repeat password');
-        $message->addSource(new FileSource($pathSubscriber, 40));
+        $message->addSource($fileSourceFactory->create($subscriberFixtureSplInfo, 40));
         $expected->add($message);
 
         $message = new Message('form.label.zip', 'address');
         $message->setDesc('ZIP');
-        $message->addSource(new FileSource($path, 51));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 51));
         $expected->add($message);
 
         $message = new Message('form.error.password_mismatch', 'validators');
         $message->setDesc('The entered passwords do not match');
-        $message->addSource(new FileSource($pathSubscriber, 42));
+        $message->addSource($fileSourceFactory->create($subscriberFixtureSplInfo, 42));
         $expected->add($message);
 
         $catalogue = $this->extract('MyFormTypeWithSubscriberAndListener.php');
@@ -286,52 +279,22 @@ class FormExtractorTest extends \PHPUnit_Framework_TestCase
         $this->testExtract();
     }
 
-    protected function setUp()
-    {
-        $docParser = new DocParser();
-        $docParser->setImports(array(
-            'desc' => 'JMS\TranslationBundle\Annotation\Desc',
-            'meaning' => 'JMS\TranslationBundle\Annotation\Meaning',
-            'ignore' => 'JMS\TranslationBundle\Annotation\Ignore',
-        ));
-        $docParser->setIgnoreNotImportedAnnotations(true);
-
-        $this->extractor = new FormExtractor($docParser, new FileSourceFactory('faux'));
-    }
-
-    private function extract($file)
-    {
-        if (!is_file($file = __DIR__.'/Fixture/'.$file)) {
-            throw new RuntimeException(sprintf('The file "%s" does not exist.', $file));
-        }
-        $file = new \SplFileInfo($file);
-
-        $lexer = new Lexer();
-        if (class_exists('PhpParser\ParserFactory')) {
-            $factory = new ParserFactory();
-            $parser = $factory->create(ParserFactory::PREFER_PHP7, $lexer);
-        } else {
-            $parser = new Parser($lexer);
-        }
-
-        $ast = $parser->parse(file_get_contents($file));
-
-        $catalogue = new MessageCatalogue();
-        $this->extractor->visitPhpFile($file, $catalogue, $ast);
-
-        return $catalogue;
-    }
-
     public function testAttrArrayForm()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/MyAttrArrayType.php';
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyAttrArrayType.php');
 
         $message = new Message('form.label.firstname');
-        $message->addSource(new FileSource($path, 31));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 31));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('MyAttrArrayType.php'));
 
+    }
+
+    protected function getDefaultExtractor()
+    {
+        return new FormExtractor($this->getDocParser(), $this->getFileSourceFactory());
     }
 }

--- a/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
@@ -31,13 +31,10 @@ use JMS\TranslationBundle\Exception\RuntimeException;
 use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExtension;
-use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Twig\TranslationExtension;
 use JMS\TranslationBundle\Translation\Extractor\File\TwigFileExtractor;
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 
 class TwigFileExtractorTest extends \PHPUnit_Framework_TestCase
@@ -45,54 +42,55 @@ class TwigFileExtractorTest extends \PHPUnit_Framework_TestCase
     public function testExtractSimpleTemplate()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/simple_template.html.twig';
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/simple_template.html.twig');
 
         $message = new Message('text.foo');
         $message->setDesc('Foo Bar');
         $message->setMeaning('Some Meaning');
-        $message->addSource(new FileSource($path, 1));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 1));
         $expected->add($message);
 
         $message = new Message('text.bar');
         $message->setDesc('Foo');
-        $message->addSource(new FileSource($path, 3));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 3));
         $expected->add($message);
 
         $message = new Message('text.baz');
         $message->setMeaning('Bar');
-        $message->addSource(new FileSource($path, 5));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 5));
         $expected->add($message);
 
         $message = new Message('text.foo_bar', 'foo');
-        $message->addSource(new FileSource($path, 7));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 7));
         $expected->add($message);
 
         $message = new Message('text.name', 'app');
-        $message->addSource(new FileSource($path, 9));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 9));
         $expected->add($message);
 
         $message = new Message('text.apple_choice', 'app');
-        $message->addSource(new FileSource($path, 11));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 11));
         $expected->add($message);
 
         $message = new Message('foo.bar');
-        $message->addSource(new FileSource($path, 13));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 13));
         $expected->add($message);
 
         $message = new Message('foo.bar2');
-        $message->addSource(new FileSource($path, 15));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 15));
         $expected->add($message);
 
         $message = new Message('foo.bar3', 'app');
-        $message->addSource(new FileSource($path, 17));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 17));
         $expected->add($message);
 
         $message = new Message('foo.bar4', 'app');
-        $message->addSource(new FileSource($path, 19));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 19));
         $expected->add($message);
 
         $message = new Message('text.default_domain');
-        $message->addSource(new FileSource($path, 21));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 21));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('simple_template.html.twig'));
@@ -101,25 +99,26 @@ class TwigFileExtractorTest extends \PHPUnit_Framework_TestCase
     public function testExtractEdit()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/edit.html.twig';
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/edit.html.twig');
 
         $message = new Message('header.edit_profile');
-        $message->addSource(new FileSource($path, 10));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 10));
         $expected->add($message);
 
         $message = new Message("text.archive");
         $message->setDesc('Archive');
         $message->setMeaning('The verb');
-        $message->addSource(new FileSource($path, 13));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 13));
         $expected->add($message);
 
         $message = new Message('button.edit_profile');
-        $message->addSource(new FileSource($path, 16));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 16));
         $expected->add($message);
 
         $message = new Message('link.cancel_profile');
         $message->setDesc('Back to Profile');
-        $message->addSource(new FileSource($path, 17));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 17));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('edit.html.twig'));
@@ -128,10 +127,11 @@ class TwigFileExtractorTest extends \PHPUnit_Framework_TestCase
     public function testEmbeddedTemplate()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/embedded_template.html.twig';
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/embedded_template.html.twig');
 
         $message = new Message('foo');
-        $message->addSource(new FileSource($path, 3));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 3));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('embedded_template.html.twig'));
@@ -168,5 +168,10 @@ class TwigFileExtractorTest extends \PHPUnit_Framework_TestCase
         $extractor->visitTwigFile(new \SplFileInfo($file), $catalogue, $ast);
 
         return $catalogue;
+    }
+
+    protected function getFileSourceFactory()
+    {
+        return new FileSourceFactory('faux');
     }
 }

--- a/Tests/Translation/Extractor/FileExtractorTest.php
+++ b/Tests/Translation/Extractor/FileExtractorTest.php
@@ -44,10 +44,11 @@ class FileExtractorTest extends \PHPUnit_Framework_TestCase
     {
         $expected = array();
         $basePath = __DIR__.'/Fixture/SimpleTest/';
+        $fileSourceFactory = new FileSourceFactory('faux');
 
         // Controller
         $message = new Message('controller.foo');
-        $message->addSource(new FileSource($basePath.'Controller/DefaultController.php', 27));
+        $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'Controller/DefaultController.php'), 27));
         $message->setDesc('Foo');
         $expected['controller.foo'] = $message;
 
@@ -58,29 +59,29 @@ class FileExtractorTest extends \PHPUnit_Framework_TestCase
         // Templates
         foreach (array('php', 'twig') as $engine) {
             $message = new Message($engine.'.foo');
-            $message->addSource(new FileSource($basePath.'Resources/views/'.$engine.'_template.html.'.$engine, 1));
+            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'Resources/views/'.$engine.'_template.html.'.$engine), 1));
             $expected[$engine.'.foo'] = $message;
 
             $message = new Message($engine.'.bar');
             $message->setDesc('Bar');
-            $message->addSource(new FileSource($basePath.'Resources/views/'.$engine.'_template.html.'.$engine, 3));
+            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'Resources/views/'.$engine.'_template.html.'.$engine), 3));
             $expected[$engine.'.bar'] = $message;
 
             $message = new Message($engine.'.baz');
             $message->setMeaning('Baz');
-            $message->addSource(new FileSource($basePath.'Resources/views/'.$engine.'_template.html.'.$engine, 5));
+            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'Resources/views/'.$engine.'_template.html.'.$engine), 5));
             $expected[$engine.'.baz'] = $message;
 
             $message = new Message($engine.'.foo_bar');
             $message->setDesc('Foo');
             $message->setMeaning('Bar');
-            $message->addSource(new FileSource($basePath.'Resources/views/'.$engine.'_template.html.'.$engine, 7));
+            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'Resources/views/'.$engine.'_template.html.'.$engine), 7));
             $expected[$engine.'.foo_bar'] = $message;
         }
 
         // File with global namespace.
         $message = new Message('globalnamespace.foo');
-        $message->addSource(new FileSource($basePath.'GlobalNamespace.php', 27));
+        $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'GlobalNamespace.php'), 27));
         $message->setDesc('Bar');
         $expected['globalnamespace.foo'] = $message;
 

--- a/Tests/Translation/FileSourceFactoryTest.php
+++ b/Tests/Translation/FileSourceFactoryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace JMS\TranslationBundle\Tests\Translation;
+
+use JMS\TranslationBundle\Translation\FileSourceFactory;
+use Nyholm\NSA;
+
+class FileSourceFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test many different path to make sure we find the relative one.
+     *
+     * @dataProvider pathProvider
+     */
+    public function testGetRelativePath($root, $file, $expected, $message = '')
+    {
+        $factory = new FileSourceFactory($root);
+        $result = NSA::invokeMethod($factory, 'getRelativePath', $file);
+
+        $this->assertEquals($expected, $result, $message);
+    }
+
+    public function pathProvider()
+    {
+        return array(
+            array(
+                '/user/foo/application/app',
+                '/user/foo/application/src/bundle/controller/index.php',
+                '/../src/bundle/controller/index.php',
+            ),
+
+            array(
+                '/user/foo/application/app/foo/bar',
+                '/user/foo/application/src/bundle/controller/index.php',
+                '/../../../src/bundle/controller/index.php',
+            ),
+
+            array(
+                '/user/foo/application/app',
+                '/user/foo/application/app/../src/AppBundle/Controller/DefaultController.php',
+                '/../src/AppBundle/Controller/DefaultController.php',
+                'Test with "/../" in the file path',
+            ),
+
+            array(
+                '/user/foo/application/app/foo/bar/baz/biz/foo',
+                '/user/foo/application/src/bundle/controller/index.php',
+                '/../../../../../../src/bundle/controller/index.php',
+                'Test when the root path is longer that file path',
+            ),
+        );
+    }
+}

--- a/Translation/FileSourceFactory.php
+++ b/Translation/FileSourceFactory.php
@@ -40,7 +40,7 @@ class FileSourceFactory
     /**
      * Generate a new FileSource with a relative path.
      *
-     * @param \SplFileInfo $file   string
+     * @param \SplFileInfo $file
      * @param null|int     $line
      * @param null|int     $column
      *
@@ -48,31 +48,42 @@ class FileSourceFactory
      */
     public function create(\SplFileInfo $file, $line = null, $column = null)
     {
-        return new FileSource(self::getRelativePath((string) $file, $this->kernelRoot), $line, $column);
+        return new FileSource($this->getRelativePath((string) $file), $line, $column);
     }
 
     /**
      * @param string $path
-     * @param string $rootPath
      *
      * @return string
      */
-    protected static function getRelativePath($path, $rootPath)
+    private function getRelativePath($path)
     {
-        if (0 === strpos($path, $rootPath)) {
-            return substr($path, strlen($rootPath));
+        if (0 === strpos($path, $this->kernelRoot)) {
+            return substr($path, strlen($this->kernelRoot));
         }
-        $ds = DIRECTORY_SEPARATOR;
-        $rootDirectoryArray = explode($ds, $rootPath);
-        $pathDirectoryArray = explode($ds, $path);
-        $relativePath = $ds;
 
-        foreach ($rootDirectoryArray as $index => $rootCurrentDirectory) {
-            $pathCurrentDirectory = array_shift($pathDirectoryArray);
+        $relativePath = $ds = DIRECTORY_SEPARATOR;
+        $rootArray = explode($ds, $this->kernelRoot);
+        $pathArray = explode($ds, $path);
+
+        // Take the first directory in the kernelRoot tree
+        foreach ($rootArray as $rootCurrentDirectory) {
+            // Take the first directory from the path tree
+            $pathCurrentDirectory = array_shift($pathArray);
+
+            // If they are not equal
             if ($pathCurrentDirectory !== $rootCurrentDirectory) {
-                $relativePath = $ds . '..' . $relativePath . $pathCurrentDirectory . $ds;
+                // Prepend $relativePath with "/.."
+                $relativePath = $ds.'..'.$relativePath;
+
+                if ($pathCurrentDirectory) {
+                    // Append the current directory
+                    $relativePath .= $pathCurrentDirectory.$ds;
+                }
             }
         }
-        return $relativePath.implode($ds, $pathDirectoryArray);
+
+        // Add the rest of the $pathArray on the relative directory
+        return rtrim($relativePath.implode($ds, $pathArray), '/');
     }
 }

--- a/Translation/FileSourceFactory.php
+++ b/Translation/FileSourceFactory.php
@@ -19,7 +19,6 @@
 namespace JMS\TranslationBundle\Translation;
 
 use JMS\TranslationBundle\Model\FileSource;
-use JMS\TranslationBundle\Util\FileUtils;
 
 class FileSourceFactory
 {
@@ -49,6 +48,31 @@ class FileSourceFactory
      */
     public function create(\SplFileInfo $file, $line = null, $column = null)
     {
-        return new FileSource(FileUtils::getRelativePath((string) $file, $this->kernelRoot), $line, $column);
+        return new FileSource(self::getRelativePath((string) $file, $this->kernelRoot), $line, $column);
+    }
+
+    /**
+     * @param string $path
+     * @param string $rootPath
+     *
+     * @return string
+     */
+    protected static function getRelativePath($path, $rootPath)
+    {
+        if (0 === strpos($path, $rootPath)) {
+            return substr($path, strlen($rootPath));
+        }
+        $ds = DIRECTORY_SEPARATOR;
+        $rootDirectoryArray = explode($ds, $rootPath);
+        $pathDirectoryArray = explode($ds, $path);
+        $relativePath = $ds;
+
+        foreach ($rootDirectoryArray as $index => $rootCurrentDirectory) {
+            $pathCurrentDirectory = array_shift($pathDirectoryArray);
+            if ($pathCurrentDirectory !== $rootCurrentDirectory) {
+                $relativePath = $ds . '..' . $relativePath . $pathCurrentDirectory . $ds;
+            }
+        }
+        return $relativePath.implode($ds, $pathDirectoryArray);
     }
 }

--- a/Translation/FileSourceFactory.php
+++ b/Translation/FileSourceFactory.php
@@ -19,6 +19,7 @@
 namespace JMS\TranslationBundle\Translation;
 
 use JMS\TranslationBundle\Model\FileSource;
+use JMS\TranslationBundle\Util\FileUtils;
 
 class FileSourceFactory
 {
@@ -40,7 +41,7 @@ class FileSourceFactory
     /**
      * Generate a new FileSource with a relative path.
      *
-     * @param \SplFileInfo $path   string
+     * @param \SplFileInfo $file   string
      * @param null|int     $line
      * @param null|int     $column
      *
@@ -48,11 +49,6 @@ class FileSourceFactory
      */
     public function create(\SplFileInfo $file, $line = null, $column = null)
     {
-        $path = (string) $file;
-        if (0 === strpos($path, $this->kernelRoot)) {
-            $path = substr($path, strlen($this->kernelRoot));
-        }
-
-        return new FileSource($path, $line, $column);
+        return new FileSource(FileUtils::getRelativePath((string) $file, $this->kernelRoot), $line, $column);
     }
 }

--- a/Util/FileUtils.php
+++ b/Util/FileUtils.php
@@ -20,7 +20,7 @@ namespace JMS\TranslationBundle\Util;
 
 use Symfony\Component\Finder\Finder;
 
-final class FileUtils
+abstract class FileUtils
 {
     /**
      * Returns the available translation files.
@@ -35,7 +35,6 @@ final class FileUtils
      *        )
      *    )
      *
-     * @param string $directory
      * @throws \RuntimeException
      *
      * @return array
@@ -57,31 +56,6 @@ final class FileUtils
         uksort($files, 'strcasecmp');
 
         return $files;
-    }
-
-    /**
-     * @param string $path
-     * @param string $rootPath
-     *
-     * @return string
-     */
-    public static function getRelativePath($path, $rootPath)
-    {
-        if (0 === strpos($path, $rootPath)) {
-            return substr($path, strlen($rootPath));
-        }
-        $ds = DIRECTORY_SEPARATOR;
-        $rootDirectoryArray = explode($ds, $rootPath);
-        $pathDirectoryArray = explode($ds, $path);
-        $relativePath = $ds;
-
-        foreach ($rootDirectoryArray as $index => $rootCurrentDirectory) {
-            $pathCurrentDirectory = array_shift($pathDirectoryArray);
-            if ($pathCurrentDirectory !== $rootCurrentDirectory) {
-                $relativePath = $ds . '..' . $relativePath . $pathCurrentDirectory . $ds;
-            }
-        }
-        return $relativePath.implode($ds, $pathDirectoryArray);
     }
 
     final private function __construct()

--- a/Util/FileUtils.php
+++ b/Util/FileUtils.php
@@ -20,7 +20,7 @@ namespace JMS\TranslationBundle\Util;
 
 use Symfony\Component\Finder\Finder;
 
-abstract class FileUtils
+final class FileUtils
 {
     /**
      * Returns the available translation files.
@@ -35,7 +35,9 @@ abstract class FileUtils
      *        )
      *    )
      *
+     * @param string $directory
      * @throws \RuntimeException
+     *
      * @return array
      */
     public static function findTranslationFiles($directory)
@@ -51,10 +53,35 @@ abstract class FileUtils
                 $file
             );
         }
-        
+
         uksort($files, 'strcasecmp');
-        
+
         return $files;
+    }
+
+    /**
+     * @param string $path
+     * @param string $rootPath
+     *
+     * @return string
+     */
+    public static function getRelativePath($path, $rootPath)
+    {
+        if (0 === strpos($path, $rootPath)) {
+            return substr($path, strlen($rootPath));
+        }
+        $ds = DIRECTORY_SEPARATOR;
+        $rootDirectoryArray = explode($ds, $rootPath);
+        $pathDirectoryArray = explode($ds, $path);
+        $relativePath = $ds;
+
+        foreach ($rootDirectoryArray as $index => $rootCurrentDirectory) {
+            $pathCurrentDirectory = array_shift($pathDirectoryArray);
+            if ($pathCurrentDirectory !== $rootCurrentDirectory) {
+                $relativePath = $ds . '..' . $relativePath . $pathCurrentDirectory . $ds;
+            }
+        }
+        return $relativePath.implode($ds, $pathDirectoryArray);
     }
 
     final private function __construct()

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,14 @@
         "twig/twig": "<1.12"
     },
     "require-dev": {
+        "phpunit/phpunit": "4.8.27",
         "psr/log": "^1.0",
         "twig/twig": "^1.12",
         "symfony/symfony": "^2.3 || ^3.0",
         "symfony/expression-language": "^2.6 || ^3.0",
         "sensio/framework-extra-bundle": "^2.3 || ^3.0",
         "jms/di-extra-bundle": "^1.1",
+        "nyholm/nsa": "^1.0.1",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2

## Description
Fixes calculations of relative path in the cases where the file path dues not start with `kernel.root_dir`.