### PR TITLE
Fix XLIFF messages status not being set appropiately

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ### 1.3.0 to UNRELEASED
 
+* Fixed new messages not showing at the top in WebUI when in XLIFF format. 
+
 ### 1.2.3 to 1.3.0
 
 * XliffMessage is improved with note elements and attributes. 

--- a/Translation/Loader/XliffLoader.php
+++ b/Translation/Loader/XliffLoader.php
@@ -65,7 +65,7 @@ class XliffLoader implements LoaderInterface
             $m->setApproved($trans['approved']=='yes');
 
             if (isset($trans->target['state'])) {
-                $m->setState($trans->target['state']);
+                $m->setState((string) $trans->target['state']);
             }
 
             // Create closure


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #392 
| License       | Apache2


## Description
XLIFF messages status was being set to a SimpleXMLElement object instead of a string.