### PR TITLE
Fixed wrong offset

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -69,7 +69,7 @@ class Configuration implements ConfigurationInterface
                                                     if (false === $pos = strpos($v, '/')) {
                                                         $bundleName = substr($v, 1);
                                                     } else {
-                                                        $bundleName = substr($v, 1, $pos - 2);
+                                                        $bundleName = substr($v, 1, $pos - 1);
                                                     }
 
                                                     $bundles = $c->getParameter('kernel.bundles');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes/no |
| Fixed tickets |  |
| License | Apache2 |
## Description

Fixed wrong offset when computing a `@bundle/folder` notation.
Currently the bundle name is `bundl`instead of `bundle`, which generates error when using the console.
