### PR TITLE
recursive directory addition; add extra flag

### DIFF
--- a/Command/ExtractTranslationCommand.php
+++ b/Command/ExtractTranslationCommand.php
@@ -59,6 +59,7 @@ class ExtractTranslationCommand extends ContainerAwareCommand
             ->addOption('default-output-format', null, InputOption::VALUE_REQUIRED, 'The default output format (defaults to xlf).')
             ->addOption('keep', null, InputOption::VALUE_NONE, 'Define if the updater service should keep the old translation (defaults to false).')
             ->addOption('external-translations-dir', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Load external translation resources')
+            ->addOption('recursive', null, InputOption::VALUE_NONE, 'When specified, all subdirectories of those specified will be included')
         ;
     }
 
@@ -95,6 +96,7 @@ class ExtractTranslationCommand extends ContainerAwareCommand
             $output->writeln(sprintf('Excluded Names: <info>%s</info>', $config->getExcludedNames() ? implode(', ', $config->getExcludedNames()) : '# none #'));
             $output->writeln(sprintf('Output-Format: <info>%s</info>', $config->getOutputFormat() ? $config->getOutputFormat() : '# whatever is present, if nothing then '.$config->getDefaultOutputFormat().' #'));
             $output->writeln(sprintf('Custom Extractors: <info>%s</info>', $config->getEnabledExtractors() ? implode(', ', array_keys($config->getEnabledExtractors())) : '# none #'));
+            $output->writeln(sprintf('Recursive: <info>%s</info>', $config->isRecursive() ? 'Yes' : 'No'));
             $output->writeln('============================================================');
 
             $updater = $this->getContainer()->get('jms_translation.updater');
@@ -207,5 +209,7 @@ class ExtractTranslationCommand extends ContainerAwareCommand
         if ($loadResource = $input->getOption('external-translations-dir')) {
             $builder->setLoadResources($loadResource);
         }
+
+        $builder->setRecursive($input->hasParameterOption('--recursive'));
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -109,6 +109,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                                 ->scalarNode('output_dir')->isRequired()->cannotBeEmpty()->end()
                                 ->scalarNode('keep')->defaultValue(false)->end()
+                                ->scalarNode('recursive')->defaultValue(false)->end()
                             ->end()
                         ->end()
                     ->end()

--- a/DependencyInjection/JMSTranslationExtension.php
+++ b/DependencyInjection/JMSTranslationExtension.php
@@ -93,6 +93,10 @@ class JMSTranslationExtension extends Extension
                 $def->addMethodCall('setLoadResources', array($extractConfig['external_translations_dirs']));
             }
 
+            if (isset($extractConfig['recursive'])) {
+                $def->addMethodCall('setRecursive', array($extractConfig['recursive']));
+            }
+
             $requests[$name] = $def;
         }
 

--- a/Tests/Functional/Command/ExtractCommandTest.php
+++ b/Tests/Functional/Command/ExtractCommandTest.php
@@ -44,6 +44,7 @@ class ExtractCommandTest extends BaseCommandTestCase
            .'Excluded Names: *Test.php, *TestCase.php'."\n"
            .'Output-Format: # whatever is present, if nothing then xlf #'."\n"
            .'Custom Extractors: # none #'."\n"
+           .'Recursive: No'."\n"
            .'============================================================'."\n"
            .'Loading catalogues from "'.$outputDir.'"'."\n"
            .'Extracting translation keys'."\n"

--- a/Tests/Translation/ExtractorManagerTest.php
+++ b/Tests/Translation/ExtractorManagerTest.php
@@ -105,6 +105,39 @@ class ExtractorManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $excludedDirsProperty->getValue($extractor));
     }
 
+    public function testRecursive()
+    {
+        $foo = $this->getMock('JMS\TranslationBundle\Translation\ExtractorInterface');
+        $logger = new NullLogger();
+
+        $extractor = new FileExtractor(new \Twig_Environment(), $logger, array());
+        $extractor->setExcludedNames(array('foo', 'bar'));
+        $extractor->setExcludedDirs(array('baz'));
+
+        $manager = $this->getManager($extractor, array(
+            'foo' => $foo,
+        ));
+        $manager->setEnabledExtractors(array('foo' => true));
+        $manager->setDirectories(array(__DIR__.'/../Functional/Fixture/TestBundle/Resources/views'));
+
+        $managerReflection   = new \ReflectionClass($manager);
+
+        $enabledExtractorsProperty = $managerReflection->getProperty('enabledExtractors');
+        $enabledExtractorsProperty->setAccessible(true);
+
+        $directoriesProperty = $managerReflection->getProperty('directories');
+        $directoriesProperty->setAccessible(true);
+
+        $this->assertEquals(array(__DIR__.'/../Functional/Fixture/TestBundle/Resources/views'),
+                $directoriesProperty->getValue($manager));
+
+        $manager->setDirectories(array(__DIR__.'/../Functional/Fixture/TestBundle/Resources/views'), true);
+        $this->assertEquals(
+                array(__DIR__.'/../Functional/Fixture/TestBundle/Resources/views', 
+                      __DIR__.'/../Functional/Fixture/TestBundle/Resources/views/Apple'),
+                $directoriesProperty->getValue($manager));
+    }
+
     private function getManager(FileExtractor $extractor = null, array $extractors = array())
     {
         $logger = new NullLogger();

--- a/Translation/Config.php
+++ b/Translation/Config.php
@@ -86,6 +86,11 @@ final class Config
     private $keepOldMessages;
 
     /**
+     * @var bool
+     */
+    private $recursive;
+
+    /**
      * @var array
      */
     private $loadResources;
@@ -105,7 +110,7 @@ final class Config
      * @param bool $keepOldMessages
      * @param array $loadResources
      */
-    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources)
+    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources, $recursive)
     {
         if (empty($translationsDir)) {
             throw new InvalidArgumentException('The directory where translations are must be set.');
@@ -145,6 +150,7 @@ final class Config
         $this->enabledExtractors = $enabledExtractors;
         $this->keepOldMessages = $keepOldMessages;
         $this->loadResources = $loadResources;
+        $this->recursive = $recursive;
     }
 
     /**
@@ -267,5 +273,21 @@ final class Config
     public function getLoadResources()
     {
         return $this->loadResources;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isRecursive()
+    {
+        return $this->recursive;
+    }
+
+    /**
+     * @param boolean
+     */
+    public function setRecursive($recursive)
+    {
+        $this->recursive = $recursive;
     }
 }

--- a/Translation/ConfigBuilder.php
+++ b/Translation/ConfigBuilder.php
@@ -79,6 +79,7 @@ final class ConfigBuilder
      * @var array
      */
     private $loadResources = array();
+    private $recursive = false;
 
     /**
      * @static
@@ -99,6 +100,7 @@ final class ConfigBuilder
         $builder->setExcludedNames($config->getExcludedNames());
         $builder->setEnabledExtractors($config->getEnabledExtractors());
         $builder->setLoadResources($config->getLoadResources());
+        $builder->setRecursive($config->isRecursive());
 
         return $builder;
     }
@@ -286,6 +288,17 @@ final class ConfigBuilder
     }
 
     /**
+     * @param bool $recursive
+     * @return $this
+     */
+    public function setRecursive($recursive)
+    {
+        $this->recursive = $recursive;
+
+        return $this;
+    }
+
+    /**
      * @return Config
      */
     public function getConfig()
@@ -302,7 +315,8 @@ final class ConfigBuilder
             $this->excludedNames,
             $this->enabledExtractors,
             $this->keepOldTranslations,
-            $this->loadResources
+            $this->loadResources,
+            $this->recursive
         );
     }
 

--- a/Translation/ExtractorManager.php
+++ b/Translation/ExtractorManager.php
@@ -20,6 +20,7 @@ namespace JMS\TranslationBundle\Translation;
 
 use JMS\TranslationBundle\Exception\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Finder\Finder;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileExtractor;
 use JMS\TranslationBundle\Logger\LoggerAwareInterface;
@@ -70,27 +71,33 @@ class ExtractorManager implements ExtractorInterface
 
     /**
      * @param array $directories
+     * @param boolean $recursive
      */
-    public function setDirectories(array $directories)
+    public function setDirectories(array $directories, $recursive = false)
     {
         $this->directories = array();
-        
         foreach ($directories as $dir) {
-            $this->addDirectory($dir);
+            $this->addDirectory($dir, $recursive);
         }
     }
 
     /**
      * @param $directory
+     * @param boolean $recursive
      * @throws \JMS\TranslationBundle\Exception\InvalidArgumentException
      */
-    public function addDirectory($directory)
+    public function addDirectory($directory, $recursive = false)
     {
         if (!is_dir($directory)) {
             throw new InvalidArgumentException(sprintf('The directory "%s" does not exist.', $directory));
         }
-
         $this->directories[] = $directory;
+        if ($recursive) {
+            $finder = new Finder();
+            foreach ($finder->directories()->in($directory) as $subdir) {
+                $this->directories[] = $subdir->getPathName();
+            }
+        }
     }
 
     /**

--- a/Translation/Updater.php
+++ b/Translation/Updater.php
@@ -244,7 +244,7 @@ class Updater
         ));
 
         $this->extractor->reset();
-        $this->extractor->setDirectories($config->getScanDirs());
+        $this->extractor->setDirectories($config->getScanDirs(), $config->isRecursive());
         $this->extractor->setExcludedDirs($config->getExcludedDirs());
         $this->extractor->setExcludedNames($config->getExcludedNames());
         $this->extractor->setEnabledExtractors($config->getEnabledExtractors());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not sure
| Fixed tickets | 
| License       | Apache2


## Description
Rather than having to specify a full list of all directories to parse, with the risk of omitting directories added to a project later, recursively parse from the specified folder (i.e. YourBundle/Resources). Reopened, was https://github.com/schmittjoh/JMSTranslationBundle/pull/261

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog

incorporate automated feedback
TestBundle is now in Fixture folder