### PR TITLE
use Fully Qualified Extension Class Name

### DIFF
--- a/Twig/DefaultApplyingNodeVisitor.php
+++ b/Twig/DefaultApplyingNodeVisitor.php
@@ -83,7 +83,7 @@ class DefaultApplyingNodeVisitor implements \Twig_NodeVisitorInterface
                 }
 
                 $transchoiceNode = new \Twig_Node_Expression_MethodCall(
-                    new \Twig_Node_Expression_ExtensionReference('jms_translation', $transNode->getLine()),
+                    new \Twig_Node_Expression_ExtensionReference('JMS\TranslationBundle\Twig\TranslationExtension', $transNode->getLine()),
                     'transchoiceWithDefault', $transchoiceArguments, $transNode->getLine());
                 $node->setNode('node', $transchoiceNode);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | possibly |
| Deprecations? | no |
| Tests pass? | ? |
| Fixed tickets |  |
| License | Apache2 |
## Description

Deprecation warning: Referencing the "JMS\TranslationBundle\Twig\TranslationExtension" extension by its name (defined by getName()) is deprecated since 1.26 and will be removed in Twig 2.0. Use the Fully Qualified Extension Class Name instead. 
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
