### PR TITLE
Fix compatibility with recent Symfony versions

### DIFF
--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -75,7 +75,8 @@ class TwigFileExtractor implements FileVisitorInterface, \Twig_NodeVisitorInterf
         if ($node instanceof TransNode) {
             $id = $node->getNode('body')->getAttribute('data');
             $domain = 'messages';
-            if (null !== $domainNode = $node->getNode('domain')) {
+            // Older version of Symfony are storing null in the node instead of omitting it
+            if ($node->hasNode('domain') && null !== $domainNode = $node->getNode('domain')) {
                 $domain = $domainNode->getAttribute('value');
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #402
| License       | Apache2


Symfony stopped storing null as the domain node, to avoid relying on the deprecated possibility of Twig to break its own API contract (which was allowing to set ``null`` in an array of nodes expected to be ``Twig_Node[]``). So we need to check whether there is a child node ``domain`` instead of always getting it directly.