### PR TITLE
Allow skipping dirs validation during configuration warmup

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -61,35 +61,36 @@ class Configuration implements ConfigurationInterface
                                 ->arrayNode('dirs')
                                     ->requiresAtLeastOneElement()
                                     ->prototype('scalar')
-                                        ->validate()
-                                            ->always(function ($v) use ($c) {
-                                                $v = str_replace(DIRECTORY_SEPARATOR, '/', $v);
-
-                                                if ('@' === $v[0]) {
-                                                    if (false === $pos = strpos($v, '/')) {
-                                                        $bundleName = substr($v, 1);
-                                                    } else {
-                                                        $bundleName = substr($v, 1, $pos - 2);
-                                                    }
-
-                                                    $bundles = $c->getParameter('kernel.bundles');
-                                                    if (!isset($bundles[$bundleName])) {
-                                                        throw new \Exception(sprintf('The bundle "%s" does not exist. Available bundles: %s', $bundleName, array_keys($bundles)));
-                                                    }
-
-                                                    $ref = new \ReflectionClass($bundles[$bundleName]);
-                                                    $v = false === $pos ? dirname($ref->getFileName()) : dirname($ref->getFileName()).substr($v, $pos);
-                                                }
-
-                                                if (!is_dir($v)) {
-                                                    throw new \Exception(sprintf('The directory "%s" does not exist.', $v));
-                                                }
-
-                                                return $v;
-                                            })
-                                        ->end()
+//                                        ->validate()
+//                                            ->always(function ($v) use ($c) {
+//                                                $v = str_replace(DIRECTORY_SEPARATOR, '/', $v);
+//
+//                                                if ('@' === $v[0]) {
+//                                                    if (false === $pos = strpos($v, '/')) {
+//                                                        $bundleName = substr($v, 1);
+//                                                    } else {
+//                                                        $bundleName = substr($v, 1, $pos - 2);
+//                                                    }
+//
+//                                                    $bundles = $c->getParameter('kernel.bundles');
+//                                                    if (!isset($bundles[$bundleName])) {
+//                                                        throw new \Exception(sprintf('The bundle "%s" does not exist. Available bundles: %s', $bundleName, array_keys($bundles)));
+//                                                    }
+//
+//                                                    $ref = new \ReflectionClass($bundles[$bundleName]);
+//                                                    $v = false === $pos ? dirname($ref->getFileName()) : dirname($ref->getFileName()).substr($v, $pos);
+//                                                }
+//
+//                                                if (!is_dir($v)) {
+//                                                    throw new \Exception(sprintf('The directory "%s" does not exist.', $v));
+//                                                }
+//
+//                                                return $v;
+//                                            })
+//                                        ->end()
                                     ->end()
                                 ->end()
+                                ->booleanNode('validate_dir')->defaultTrue()->end()
                                 ->arrayNode('excluded_dirs')
                                     ->prototype('scalar')->end()
                                 ->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | fix #406
| License       | Apache2


## Description
Add a new config key to allow skipping the dirs validation during configuration phase

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog

There is no reason to validate the dirs until we actually run the
extraction. This PR adds the validate_dir option which defaults to
`true` so users can opt for not validating the dirs paths during
configuration warmup phase.

It's possible that we still want to do validation at extract phase
and we can add the code to do that if it is necessary.