### PR TITLE
Removed reliance on DiExtraBundle annotations.

### DIFF
--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -23,7 +23,6 @@ use JMS\TranslationBundle\Translation\ConfigFactory;
 use JMS\TranslationBundle\Translation\Updater;
 use Symfony\Component\HttpFoundation\Response;
 use JMS\TranslationBundle\Util\FileUtils;
-use JMS\DiExtraBundle\Annotation as DI;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
@@ -36,16 +35,26 @@ use Symfony\Component\HttpFoundation\Request;
 class ApiController
 {
     /**
-     * @DI\Inject("jms_translation.config_factory")
      * @var ConfigFactory
      */
     private $configFactory;
 
     /**
-     * @DI\Inject("jms_translation.updater")
      * @var Updater
      */
     private $updater;
+
+    /**
+     * ApiController constructor.
+     *
+     * @param ConfigFactory $configFactory
+     * @param Updater       $updater
+     */
+    public function __construct(ConfigFactory $configFactory, Updater $updater)
+    {
+        $this->configFactory = $configFactory;
+        $this->updater = $updater;
+    }
 
     /**
      * @Route("/configs/{config}/domains/{domain}/locales/{locale}/messages",

--- a/Controller/TranslateController.php
+++ b/Controller/TranslateController.php
@@ -22,11 +22,9 @@ use JMS\TranslationBundle\Exception\RuntimeException;
 use JMS\TranslationBundle\Translation\ConfigFactory;
 use JMS\TranslationBundle\Translation\LoaderManager;
 use JMS\TranslationBundle\Util\FileUtils;
-use JMS\DiExtraBundle\Annotation as DI;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Translation\MessageCatalogue;
 
 /**
  * Translate Controller.
@@ -36,22 +34,39 @@ use Symfony\Component\Translation\MessageCatalogue;
 class TranslateController
 {
     /**
-     * @DI\Inject("jms_translation.config_factory")
      * @var ConfigFactory
      */
     private $configFactory;
 
     /**
-     * @DI\Inject("jms_translation.loader_manager")
      * @var LoaderManager
      */
     private $loader;
 
     /**
-     * @DI\Inject("%jms_translation.source_language%")
      * @var string
      */
     private $sourceLanguage;
+
+    /**
+     * TranslateController constructor.
+     *
+     * @param ConfigFactory $configFactory
+     * @param LoaderManager $loader
+     */
+    public function __construct(ConfigFactory $configFactory, LoaderManager $loader)
+    {
+        $this->configFactory = $configFactory;
+        $this->loader = $loader;
+    }
+
+    /**
+     * @param string $lang
+     */
+    public function setSourceLanguage($lang)
+    {
+        $this->sourceLanguage = $lang;
+    }
 
     /**
      * @Route("/", name="jms_translation_index", options = {"i18n" = false})

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,6 +7,9 @@
     <parameters>
         <parameter key="jms_translation.twig_extension.class">JMS\TranslationBundle\Twig\TranslationExtension</parameter>
 
+        <parameter key="jms_translation.controller.translate_controller.class">JMS\TranslationBundle\Controller\TranslateController</parameter>
+        <parameter key="jms_translation.controller.api_controller.class">JMS\TranslationBundle\Controller\ApiController</parameter>
+
         <parameter key="jms_translation.extractor_manager.class">JMS\TranslationBundle\Translation\ExtractorManager</parameter>
         <parameter key="jms_translation.extractor.file_extractor.class">JMS\TranslationBundle\Translation\Extractor\FileExtractor</parameter>
         <parameter key="jms_translation.extractor.file.default_php_extractor">JMS\TranslationBundle\Translation\Extractor\File\DefaultPhpFileExtractor</parameter>
@@ -34,6 +37,20 @@
     </parameters>
 
     <services>
+        <!-- Controllers -->
+        <service id="jms_translation.controller.translate_controller" class="%jms_translation.controller.translate_controller.class%">
+            <argument id="jms_translation.config_factory" type="service"/>
+            <argument id="jms_translation.loader_manager" type="service"/>
+            <call method="setSourceLanguage">
+                <argument>%jms_translation.source_language%</argument>
+            </call>
+        </service>
+        <service id="jms_translation.controller.api_controller" class="%jms_translation.controller.api_controller.class%">
+            <argument id="jms_translation.config_factory" type="service"/>
+            <argument id="jms_translation.updater" type="service"/>
+        </service>
+
+
         <service id="jms_translation.updater" class="%jms_translation.updater.class%">
             <argument type="service" id="jms_translation.loader_manager" />
             <argument type="service" id="jms_translation.extractor_manager" />

--- a/Tests/Functional/AppKernel.php
+++ b/Tests/Functional/AppKernel.php
@@ -51,8 +51,6 @@ class AppKernel extends Kernel
             new \Symfony\Bundle\TwigBundle\TwigBundle(),
             new \JMS\TranslationBundle\JMSTranslationBundle(),
             new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
-            new \JMS\DiExtraBundle\JMSDiExtraBundle($this),
-            new \JMS\AopBundle\JMSAopBundle(),
         );
     }
 

--- a/Tests/Functional/Fixture/TestBundle/Controller/AppleController.php
+++ b/Tests/Functional/Fixture/TestBundle/Controller/AppleController.php
@@ -2,8 +2,6 @@
 
 namespace JMS\TranslationBundle\Tests\Functional\Fixture\TestBundle\Controller;
 
-use JMS\DiExtraBundle\Annotation as DI;
-use JMS\SecurityExtraBundle\Annotation\PreAuthorize;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "symfony/symfony": "^2.3 || ^3.0",
         "symfony/expression-language": "^2.6 || ^3.0",
         "sensio/framework-extra-bundle": "^2.3 || ^3.0",
-        "jms/di-extra-bundle": "^1.1",
         "nyholm/nsa": "^1.0.1",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #355 |
| License | Apache2 |
## Description

Simply removed the implicit DI and replaced with formal parameters in the services configuration.
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
