### PR TITLE
Make the bundle Twig >=1.27 ready

### DIFF
--- a/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
@@ -162,7 +162,7 @@ class TwigFileExtractorTest extends \PHPUnit_Framework_TestCase
             $extractor = new TwigFileExtractor($env, new FileSourceFactory('faux'));
         }
 
-        $ast = $env->parse($env->tokenize(file_get_contents($file), $file));
+        $ast = $env->parse($env->tokenize(new \Twig_Source(file_get_contents($file), $file)));
 
         $catalogue = new MessageCatalogue();
         $extractor->visitTwigFile(new \SplFileInfo($file), $catalogue, $ast);

--- a/Tests/Twig/BaseTwigTestCase.php
+++ b/Tests/Twig/BaseTwigTestCase.php
@@ -25,15 +25,18 @@ use JMS\TranslationBundle\Twig\TranslationExtension;
 
 abstract class BaseTwigTestCase extends \PHPUnit_Framework_TestCase
 {
-    final protected function parse($file, $debug = false)
+    final protected function parse($file, $debug = false, $hard_filename = null)
     {
         $content = file_get_contents(__DIR__.'/Fixture/'.$file);
+        if (null === $hard_filename) {
+        	$hard_filename = $file;
+        }
+        $source = new \Twig_Source($content, $hard_filename);
 
         $env = new \Twig_Environment();
         $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
         $env->addExtension(new TranslationExtension($translator, $debug));
-        $env->setLoader(new \Twig_Loader_String());
 
-        return $env->parse($env->tokenize($content));
+        return $env->parse($env->tokenize($source));
     }
 }

--- a/Tests/Twig/DefaultApplyingNodeVisitorTest.php
+++ b/Tests/Twig/DefaultApplyingNodeVisitorTest.php
@@ -22,9 +22,9 @@ class DefaultApplyingNodeVisitorTest extends BaseTwigTestCase
 {
     public function testApply()
     {
-        $this->assertEquals(
-            $this->parse('apply_default_value_compiled.html.twig', true),
-            $this->parse('apply_default_value.html.twig', true)
-        );
+        $expected = $this->parse('apply_default_value_compiled.html.twig', true);
+        $actual = $this->parse('apply_default_value.html.twig', true, 'apply_default_value_compiled.html.twig');
+
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/Tests/Twig/NormalizingNodeVisitorTest.php
+++ b/Tests/Twig/NormalizingNodeVisitorTest.php
@@ -22,9 +22,9 @@ class NormalizingNodeVisitorTest extends BaseTwigTestCase
 {
     public function testBinaryConcatOfConstants()
     {
-        $this->assertEquals(
-            $this->parse('binary_concat_of_constants_compiled.html.twig'),
-            $this->parse('binary_concat_of_constants.html.twig')
-        );
+        $expected = $this->parse('binary_concat_of_constants_compiled.html.twig');
+        $actual = $this->parse('binary_concat_of_constants.html.twig', false, 'binary_concat_of_constants_compiled.html.twig');
+
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/Tests/Twig/RemovingNodeVisitorTest.php
+++ b/Tests/Twig/RemovingNodeVisitorTest.php
@@ -23,7 +23,7 @@ class RemovingNodeVisitorTest extends BaseTwigTestCase
     public function testRemovalWithSimpleTemplate()
     {
         $expected = $this->parse('simple_template_compiled.html.twig');
-        $actual = $this->parse('simple_template.html.twig');
+        $actual = $this->parse('simple_template.html.twig', false, 'simple_template_compiled.html.twig');
 
         $this->assertEquals($expected, $actual);
     }

--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -81,7 +81,7 @@ class TwigFileExtractor implements FileVisitorInterface, \Twig_NodeVisitorInterf
             }
 
             $message = new Message($id, $domain);
-            $message->addSource($this->fileSourceFactory->create($this->file, $node->getLine()));
+            $message->addSource($this->fileSourceFactory->create($this->file, $node->getTemplateLine()));
             $this->catalogue->add($message);
         } elseif ($node instanceof \Twig_Node_Expression_Filter) {
             $name = $node->getNode('filter')->getAttribute('value');
@@ -110,7 +110,7 @@ class TwigFileExtractor implements FileVisitorInterface, \Twig_NodeVisitorInterf
                 }
 
                 $message = new Message($id, $domain);
-                $message->addSource($this->fileSourceFactory->create($this->file, $node->getLine()));
+                $message->addSource($this->fileSourceFactory->create($this->file, $node->getTemplateLine()));
 
                 for ($i=count($this->stack)-2; $i>=0; $i-=1) {
                     if (!$this->stack[$i] instanceof \Twig_Node_Expression_Filter) {

--- a/Translation/Extractor/FileExtractor.php
+++ b/Translation/Extractor/FileExtractor.php
@@ -227,7 +227,7 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
                         $visitingArgs[] = $ast;
                     } elseif ('twig' === $extension) {
                         $visitingMethod = 'visitTwigFile';
-                        $visitingArgs[] = $this->twig->parse($this->twig->tokenize(file_get_contents($file), (string) $file));
+                        $visitingArgs[] = $this->twig->parse($this->twig->tokenize(new \Twig_Source(file_get_contents($file), (string) $file)));
                     }
                 }
 

--- a/Twig/DefaultApplyingNodeVisitor.php
+++ b/Twig/DefaultApplyingNodeVisitor.php
@@ -75,7 +75,7 @@ class DefaultApplyingNodeVisitor implements \Twig_NodeVisitorInterface
             // so that we can catch a possible exception when the default translation has not yet
             // been extracted
             if ('transchoice' === $transNode->getNode('filter')->getAttribute('value')) {
-                $transchoiceArguments = new \Twig_Node_Expression_Array(array(), $transNode->getLine());
+                $transchoiceArguments = new \Twig_Node_Expression_Array(array(), $transNode->getTemplateLine());
                 $transchoiceArguments->addElement($wrappingNode->getNode('node'));
                 $transchoiceArguments->addElement($defaultNode);
                 foreach ($wrappingNode->getNode('arguments') as $arg) {
@@ -83,8 +83,8 @@ class DefaultApplyingNodeVisitor implements \Twig_NodeVisitorInterface
                 }
 
                 $transchoiceNode = new \Twig_Node_Expression_MethodCall(
-                    new \Twig_Node_Expression_ExtensionReference('jms_translation', $transNode->getLine()),
-                    'transchoiceWithDefault', $transchoiceArguments, $transNode->getLine());
+                    new \Twig_Node_Expression_ExtensionReference('jms_translation', $transNode->getTemplateLine()),
+                    'transchoiceWithDefault', $transchoiceArguments, $transNode->getTemplateLine());
                 $node->setNode('node', $transchoiceNode);
 
                 return $node;
@@ -93,7 +93,7 @@ class DefaultApplyingNodeVisitor implements \Twig_NodeVisitorInterface
             // if the |trans filter has replacements parameters
             // (e.g. |trans({'%foo%': 'bar'}))
             if ($wrappingNode->getNode('arguments')->hasNode(0)) {
-                $lineno =  $wrappingNode->getLine();
+                $lineno =  $wrappingNode->getTemplateLine();
 
                 // remove the replacements from the test node
                 $testNode->setNode('arguments', clone $testNode->getNode('arguments'));
@@ -111,10 +111,10 @@ class DefaultApplyingNodeVisitor implements \Twig_NodeVisitorInterface
             }
 
             $condition = new \Twig_Node_Expression_Conditional(
-                new \Twig_Node_Expression_Binary_Equal($testNode, $transNode->getNode('node'), $wrappingNode->getLine()),
+                new \Twig_Node_Expression_Binary_Equal($testNode, $transNode->getNode('node'), $wrappingNode->getTemplateLine()),
                 $defaultNode,
                 clone $wrappingNode,
-                $wrappingNode->getLine()
+                $wrappingNode->getTemplateLine()
             );
             $node->setNode('node', $condition);
         }

--- a/Twig/NormalizingNodeVisitor.php
+++ b/Twig/NormalizingNodeVisitor.php
@@ -46,9 +46,9 @@ class NormalizingNodeVisitor implements \Twig_NodeVisitorInterface
     public function leaveNode(\Twig_NodeInterface $node, \Twig_Environment $env)
     {
         if ($node instanceof \Twig_Node_Expression_Binary_Concat
-            && ($left = $node->getNode('left')) instanceof \Twig_Node_Expression_Constant
-            && ($right = $node->getNode('right')) instanceof \Twig_Node_Expression_Constant) {
-            return new \Twig_Node_Expression_Constant($left->getAttribute('value').$right->getAttribute('value'), $left->getLine());
+                && ($left = $node->getNode('left')) instanceof \Twig_Node_Expression_Constant
+                && ($right = $node->getNode('right')) instanceof \Twig_Node_Expression_Constant) {
+            return new \Twig_Node_Expression_Constant($left->getAttribute('value').$right->getAttribute('value'), $left->getTemplateLine());
         }
 
         return $node;

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/console": "^2.3 || ^3.0"
     },
     "conflict": {
-        "twig/twig": "<1.12"
+        "twig/twig": "<1.27"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.27",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | depends, see below
| Deprecations? | no
| Tests pass?   | no, see below
| Fixed tickets | 
| License       | Apache2


## Description
When using Twig >= 1.27 you get several deprecation notices (in both the Twig extractor and also in the Twig visitors). This PR tries to eliminate these notices.

However, I noticed the build already fails on the current (proposed) master (see https://travis-ci.org/schmittjoh/JMSTranslationBundle/jobs/181338445). This was not the case when master was built/tested on Travis during the last commit (of stof): https://travis-ci.org/schmittjoh/JMSTranslationBundle/jobs/166781674. Cause of this is probably Twig 1.28. Current master was tested with Twig 1.26.

So, this PR has the same three tests failing too. Don't know what I exactly need to fix to get the three visitors working again, any help would be appreciated :].

Regarding the BC break. As you can see, I've updated the Twig conflict constraint. Because we are now using the `\Twig_Source` class and the `getTemplateLine()` method, that were both not available pre-1.27. I was however wondering whether this updated constraint would be considered a BC break?

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog

