### PR TITLE
custom constraints message extractor (#423)

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,6 +15,7 @@
         <parameter key="jms_translation.extractor.file.form_extractor.class">JMS\TranslationBundle\Translation\Extractor\File\FormExtractor</parameter>
         <parameter key="jms_translation.extractor.file.validation_extractor.class">JMS\TranslationBundle\Translation\Extractor\File\ValidationExtractor</parameter>
         <parameter key="jms_translation.extractor.file.authentication_message_extractor.class">JMS\TranslationBundle\Translation\Extractor\File\AuthenticationMessagesExtractor</parameter>
+        <parameter key="jms_translation.extractor.file.constraint_message_extractor.class">JMS\TranslationBundle\Translation\Extractor\File\ConstraintMessageExtractor</parameter>
 
         <parameter key="jms_translation.loader.symfony.xliff_loader.class">JMS\TranslationBundle\Translation\Loader\Symfony\XliffLoader</parameter>
         <parameter key="jms_translation.loader.xliff_loader.class">JMS\TranslationBundle\Translation\Loader\XliffLoader</parameter>
@@ -113,6 +114,9 @@
         <service id="jms_translation.extractor.file.authentication_message_extractor" class="%jms_translation.extractor.file.authentication_message_extractor.class%" public="false">
             <argument type="service" id="jms_translation.doc_parser" />
             <argument type="service" id="jms_translation.file_source_factory" />
+            <tag name="jms_translation.file_visitor" />
+        </service>
+        <service id="jms_translation.extractor.file.constraint_message_extractor" class="%jms_translation.extractor.file.constraint_message_extractor.class%" public="false">
             <tag name="jms_translation.file_visitor" />
         </service>
 

--- a/Translation/Extractor/File/ConstraintMessageExtractor.php
+++ b/Translation/Extractor/File/ConstraintMessageExtractor.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace JMS\TranslationBundle\Translation\Extractor\File;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+use Symfony\Component\Validator\Constraint;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+
+class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
+{
+
+    /**
+     * @var NodeTraverser
+     */
+    private $traverser;
+
+    /**
+     * @var \SplFileInfo
+     */
+    private $file;
+
+    /**
+     * @var MessageCatalogue
+     */
+    private $catalogue;
+
+    /**
+     * @var string
+     */
+    private $namespace = '';
+
+    /**
+     * ValidationExtractor constructor.
+     */
+    public function __construct()
+    {
+        $this->traverser = new NodeTraverser();
+        $this->traverser->addVisitor($this);
+    }
+
+    /**
+     * @param Node $node
+     * @return void
+     */
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Node\Stmt\Namespace_) {
+            if (isset($node->name)) {
+                $this->namespace = implode('\\', $node->name->parts);
+            }
+
+            return;
+        }
+
+        if (!$node instanceof Node\Stmt\Class_) {
+            return;
+        }
+
+        $name = '' === $this->namespace ? $node->name : $this->namespace.'\\'.$node->name;
+
+        if ($node instanceof Node\Stmt\Class_) {
+            if (!class_exists($name)) {
+                return;
+            }
+            $ref = new \ReflectionClass($name);
+            if (!$ref->isSubclassOf('Symfony\Component\Validator\Constraint')) {
+                return;
+            } else {
+                $constraint = $ref->newInstance();
+                /** @var Constraint $constraint */
+                $this->extractFromConstraint($constraint);
+            }
+        }
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     * @param MessageCatalogue $catalogue
+     * @param array $ast
+     */
+    public function visitPhpFile(\SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
+    {
+        $this->file = $file;
+        $this->namespace = '';
+        $this->catalogue = $catalogue;
+        $this->traverser->traverse($ast);
+    }
+
+    /**
+     * @param array $nodes
+     * @return void
+     */
+    public function beforeTraverse(array $nodes)
+    {
+    }
+
+    /**
+     * @param Node $node
+     * @return void
+     */
+    public function leaveNode(Node $node)
+    {
+    }
+
+    /**
+     * @param array $nodes
+     * @return void
+     */
+    public function afterTraverse(array $nodes)
+    {
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     * @param MessageCatalogue $catalogue
+     */
+    public function visitFile(\SplFileInfo $file, MessageCatalogue $catalogue)
+    {
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     * @param MessageCatalogue $catalogue
+     * @param \Twig_Node $ast
+     */
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    {
+    }
+
+    /**
+     * @param Constraint $constraint
+     */
+    private function extractFromConstraint(Constraint $constraint)
+    {
+        $ref = new \ReflectionClass($constraint);
+
+        $properties = $ref->getProperties();
+
+        foreach ($properties as $property) {
+            $propName = $property->getName();
+
+            // If the property ends with 'Message'
+            if (strtolower(substr($propName, -1 * strlen('Message'))) === 'message') {
+                $message = new Message($constraint->{$propName}, 'validators');
+                $this->catalogue->add($message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #423
| License       | Apache2


## Description
Extractor of messages from custom constraints, which defined not with annotations. For example directly in forms.
Extracts messages from properties ending with ...message, as it was implemented in https://github.com/schmittjoh/JMSTranslationBundle/pull/160
