### PR TITLE
PhpFileExtractor: Add $defaultDomain variable instead of hard coded

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ### 1.3.1 to UNRELEASED
 
+* DefaultPhpFileExtractor can be extended to define domain where should be extracted messages.
+
 ### 1.3.0 to 1.3.1
 
 * Fixed new messages not showing at the top in WebUI when in XLIFF format.

--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -90,6 +90,11 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
     );
 
     /**
+     * @var string
+     */
+    protected $defaultDomain = 'messages';
+
+    /**
      * DefaultPhpFileExtractor constructor.
      * @param DocParser $docParser
      * @param FileSourceFactory $fileSourceFactory
@@ -176,7 +181,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
 
             $domain = $node->args[$index]->value->value;
         } else {
-            $domain = 'messages';
+            $domain = $this->defaultDomain;
         }
 
         $message = new Message($id, $domain);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description

Add $defaultDomain variable instead of hard coded  'messages' string to ease extension.

This allow developer to extend DefaultPhpFileExtractor to extract to custom domain.

ex : https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/MVC/Symfony/Translation/ExceptionMessageTemplateFileVisitor.php


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
