### PR TITLE
Use `same as` for twig 1.21 deprecated compliance

### DIFF
--- a/Resources/views/Translate/index.html.twig
+++ b/Resources/views/Translate/index.html.twig
@@ -4,7 +4,7 @@
     {{ parent() }}
     <script language="javascript" type="text/javascript">
         var updateMessagePath = {{ path("jms_translation_update_message", {"config": selectedConfig, "domain": selectedDomain, "locale": selectedLocale})|json_encode|raw }};
-        var isWritable        = {{ isWriteable is sameas(true) ? 'true' : 'false' }};
+        var isWritable        = {{ isWriteable is same as(true) ? 'true' : 'false' }};
         var JMS               = new JMSTranslationManager(updateMessagePath, isWritable);
 
         JMS.ready();
@@ -33,7 +33,7 @@
         </select>
     </form>
     
-    {% if isWriteable is sameas(false) %}
+    {% if isWriteable is same as(false) %}
     <div class="alert-message error">
         The translation file "<strong>{{ file }}</strong>" is not writable.
     </div>

--- a/Resources/views/Translate/messages.html.twig
+++ b/Resources/views/Translate/messages.html.twig
@@ -14,7 +14,7 @@
                     <p><abbr title="{{ id }}">{{ id|slice(0, 25) }}{% if id|length > 25 %}...{% endif %}</abbr></p>
                 </td>
                 <td>
-                    <textarea data-id="{{ id }}" class="span6"{% if isWriteable is sameas(false) %} readonly="readonly"{% endif %}>{{ message.localeString }}</textarea></td>
+                    <textarea data-id="{{ id }}" class="span6"{% if isWriteable is same as(false) %} readonly="readonly"{% endif %}>{{ message.localeString }}</textarea></td>
                 <td>
                     {% if message.meaning is not empty %}
                         <h6>Meaning</h6>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | no :/ but they don't pass for master either...
| Fixed tickets | 
| License       | Apache2


## Description
Replaced deprecated twig function `sameas` (since 1.21) by recommended `same as`
