### PR TITLE
support nikic/php-parser 3.0 / php7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 env:
@@ -32,8 +33,17 @@ matrix:
           env: SYMFONY_VERSION=2.3.*
         - php: 5.6
           env: SYMFONY_VERSION=2.7.*
+        - php: 7.0
+          env: SYMFONY_VERSION=2.7.*
+        - php: 7.1
+          env: SYMFONY_VERSION=2.8.*
         - php: 5.6
-          env: SYMFONY_VERSION=3.0.*
+          env: SYMFONY_VERSION=^3.0
+        - php: 7.0
+          env: SYMFONY_VERSION=^3.0
+        - php: 7.1
+          env: SYMFONY_VERSION=^3.0
+
 
 before_install:
     - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^5.3.3 || ^7.0",
         "twig/twig": "^1.27 || ^2.0",
         "symfony/framework-bundle": "^2.3 || ^3.0",
-        "nikic/php-parser": "^1.4 || ^2.0",
+        "nikic/php-parser": "^1.4 || ^2.0 || ^3.0",
         "symfony/console": "^2.3 || ^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
Adds php 7.1 to the test matrix and bumps allowed php-parser version to be 3.0
