### PR TITLE
Fix PHP Notice: "Array to string conversion"

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -81,7 +81,7 @@ class Configuration implements ConfigurationInterface
 
                                                     $bundles = $c->getParameter('kernel.bundles');
                                                     if (!isset($bundles[$bundleName])) {
-                                                        throw new \Exception(sprintf('The bundle "%s" does not exist. Available bundles: %s', $bundleName, array_keys($bundles)));
+                                                        throw new \Exception(sprintf('The bundle "%s" does not exist. Available bundles: %s', $bundleName, implode(', ', array_keys($bundles))));
                                                     }
 
                                                     $ref = new \ReflectionClass($bundles[$bundleName]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | untested case?
| Fixed tickets | hotfix
| License       | Apache2


## Description
Configuration validation was throwing `Symfony\Component\Debug\Exception\ContextErrorException` caused by:

```
Notice: Array to string conversion in /Users/marek/workspace/gg/website/vendor/jms/translation-bundle/JMS/TranslationBundle/DependencyInjection/Configuration.php:84
```

in case provided provided `dir` is prefixed with not existing bundle.

Wrapping `array_keys` with `implode(', ', ...)` fixes the issue.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
