### PR TITLE
Fixed twig node visitor signature

### DIFF
--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -68,7 +68,7 @@ class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInte
      * @param \Twig_Environment $env
      * @return \Twig_Node
      */
-    public function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
     {
         $this->stack[] = $node;
 
@@ -187,7 +187,7 @@ class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInte
      * @param \Twig_Environment $env
      * @return \Twig_Node
      */
-    public function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
     {
         array_pop($this->stack);
 

--- a/Twig/NormalizingNodeVisitor.php
+++ b/Twig/NormalizingNodeVisitor.php
@@ -33,7 +33,7 @@ class NormalizingNodeVisitor extends \Twig_BaseNodeVisitor
      * @param \Twig_Environment $env
      * @return \Twig_Node
      */
-    public function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
     {
         return $node;
     }
@@ -43,7 +43,7 @@ class NormalizingNodeVisitor extends \Twig_BaseNodeVisitor
      * @param \Twig_Environment $env
      * @return \Twig_Node_Expression_Constant|\Twig_Node
      */
-    public function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
     {
         if ($node instanceof \Twig_Node_Expression_Binary_Concat
             && ($left = $node->getNode('left')) instanceof \Twig_Node_Expression_Constant

--- a/Twig/RemovingNodeVisitor.php
+++ b/Twig/RemovingNodeVisitor.php
@@ -43,7 +43,7 @@ class RemovingNodeVisitor extends \Twig_BaseNodeVisitor
      * @param \Twig_Environment $env
      * @return \Twig_Node
      */
-    public function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
     {
         if ($this->enabled && $node instanceof \Twig_Node_Expression_Filter) {
             $name = $node->getNode('filter')->getAttribute('value');
@@ -61,7 +61,7 @@ class RemovingNodeVisitor extends \Twig_BaseNodeVisitor
      * @param \Twig_Environment $env
      * @return \Twig_Node
      */
-    public function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
     {
         return $node;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
Previous PR by @emodric added the Twig 2.0 compatibility by extending the `\Twig_BaseNodeVisitor` on twig visitor nodes.
But the methods `doEnterNode ` and `doLeaveNode` are declared protected on inherited class.

This PR declare these methods as protected as they should be.
I flagged this as BC break because of this, but not sure if it's relevant in this case.