### PR TITLE
Fixes translation_domain detection with setDefault

### DIFF
--- a/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithDefaultDomainSetDefault.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithDefaultDomainSetDefault.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\TranslationBundle\Tests\Translation\Extractor\File\Fixture;
+
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class MyFormType extends AbstractType
+{
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        $builder
+            ->add('firstname', 'text', array(
+                'label' => 'form.label.firstname',
+            ))
+            ->add('lastname', 'text', array(
+                'label' => /** @Desc("Lastname") */ 'form.label.lastname',
+            ))
+            ->add('street', 'text', array(
+                'label' => /** @Desc("Street") */ 'form.label.street',
+                'translation_domain' => 'address'
+            ))
+        ;
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefault('translation_domain', 'person');
+        $resolver->setDefault('other_option', 'should_not_override_domain');
+    }
+}

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -196,15 +196,11 @@ class FormExtractorTest extends BasePhpFileExtractorTest
         $this->assertEquals($expected, $this->extract('MyFormTypeWithInterface.php'));
     }
 
-    /**
-     * This test is used to check if the default 'translation_domain' option
-     * set for the entire form is extracted correctly
-     */
-    public function testExtractWithDefaultDomain()
+    protected function getDefaultDomainFixture($fixtureFile)
     {
         $expected = new MessageCatalogue();
         $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyFormTypeWithDefaultDomain.php');
+        $fixtureSplInfo = new \SplFileInfo($fixtureFile);
 
         $message = new Message('form.label.lastname', 'person');
         $message->setDesc('Lastname');
@@ -220,7 +216,25 @@ class FormExtractorTest extends BasePhpFileExtractorTest
         $message->addSource($fileSourceFactory->create($fixtureSplInfo, 37));
         $expected->add($message);
 
-        $this->assertEquals($expected, $this->extract('MyFormTypeWithDefaultDomain.php'));
+        return $expected;
+    }
+
+    /**
+     * This test is used to check if the default 'translation_domain' option
+     * set for the entire form is extracted correctly
+     */
+    public function testExtractWithDefaultDomain()
+    {
+        $this->assertEquals($this->getDefaultDomainFixture(__DIR__.'/Fixture/MyFormTypeWithDefaultDomain.php'), $this->extract('MyFormTypeWithDefaultDomain.php'));
+    }
+
+    /**
+     * This test is used to check if the default 'translation_domain' option
+     * set for the entire form is extracted correctly when set via setDefault
+     */
+    public function testExtractWithDefaultDomainSetDefault()
+    {
+        $this->assertEquals($this->getDefaultDomainFixture(__DIR__.'/Fixture/MyFormTypeWithDefaultDomainSetDefault.php'), $this->extract('MyFormTypeWithDefaultDomainSetDefault.php'));
     }
 
     /**

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -107,7 +107,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
             }
 
             $name = strtolower($node->name);
-            if ('setdefaults' === $name || 'replacedefaults' === $name) {
+            if ('setdefaults' === $name || 'replacedefaults' === $name || 'setdefault' === $name) {
                 $this->parseDefaultsCall($node);
                 return;
             }
@@ -307,6 +307,15 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
 
         // check if options were passed
         if (!isset($node->args[0])) {
+            return;
+        }
+
+        if (isset($node->args[1])
+            && $node->args[0]->value instanceof Node\Scalar\String_
+            && $node->args[1]->value instanceof Node\Scalar\String_
+            && 'translation_domain' === $node->args[0]->value->value
+        ) {
+            $this->defaultDomain =  $node->args[1]->value->value;
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2

## Description
The default translation_domain of a form was only detected if it's set via
```php
$resolver->setDefaults(array(
  'translation_domain' => 'person'
));
```
This PR adds detection if the domain is set with the singluar setDefault method.
```php
$resolver->setDefault('translation_domain', 'person');
```
