### PR TITLE
Allow user to filter messages in the web-ui

### DIFF
--- a/Resources/public/js/jms.js
+++ b/Resources/public/js/jms.js
@@ -50,6 +50,10 @@ function JMSTranslationManager(updateMessagePath, isWritable)
         handlers: function(JMS)
         {
             $(JMS.domain.selector).change(function() {
+                if(this.name === 'locale'){
+                    var filter = $(JMS.messageFilter.selector).val();
+                    $(this).parent().attr('action', $(this).parent().attr('action') + "#" + filter);
+                }
                 $(this).parent().submit();
             });
         }
@@ -175,6 +179,11 @@ function JMSTranslationManager(updateMessagePath, isWritable)
         $(document).ready(function(event) {
             JMS.domain.handlers(JMS);
             JMS.truncator.truncate(JMS);
+            $(JMS.messageFilter.selector).keyup(function(){
+                JMS.messageFilter.filter();
+            });
+            JMS.messageFilter.init();
+            JMS.messageFilter.filter();
             if(JMS.isWritable)
             {
                 JMS.writable(JMS);
@@ -194,5 +203,32 @@ function JMSTranslationManager(updateMessagePath, isWritable)
                 JMS.translation.focus(event, JMS);
             })
         ;
+    };
+
+    this.messageFilter = {
+        selector: "#filter",
+        init: function(){
+            $(JMS.messageFilter.selector).val(window.location.hash.substr(1));
+        },
+        filter: function () {
+            var filterString = $(JMS.messageFilter.selector).val().trim().replace(/[-[\]{}()+?,\\^$|#\s]/g, "\\$&");
+            var regExp = new RegExp(".*" + filterString + ".*", "i");
+            window.location.hash = filterString;
+            if (filterString !== "") {
+                $(".messageRow").each(function () {
+                    var id = this.id.substr(4);
+                    if (id.match(regExp)) {
+                        $(this).show();
+                    } else {
+                        $(this).hide();
+                    }
+                });
+
+            } else {
+                $(".messageRow").each(function () {
+                    $(this).show();
+                });
+            }
+        }
     };
 };

--- a/Resources/views/Translate/index.html.twig
+++ b/Resources/views/Translate/index.html.twig
@@ -51,6 +51,10 @@
     {% endif %}
 
     <h2>Available Messages</h2>
+	<h3>
+		Filter messages by Id
+		<input id="filter" placeholder="Enter a key to filter the entries." title="A wildcard/regexp-search for '*your_key*' will be done. You can also use the '.' as 1-char wildcard, '.*' as wildcard for 0-n chars. Search the web for 'JS Regex Documentation' for more information about regular expressions."/>
+	</h3>
 
     {% if newMessages is not empty %}
     <h3>New Messages</h3>

--- a/Resources/views/Translate/messages.html.twig
+++ b/Resources/views/Translate/messages.html.twig
@@ -8,7 +8,7 @@
         </thead>
         <tbody>
             {% for id, message in messages %}
-            <tr>
+            <tr class="messageRow" id="row-{{ id }}">
                 <td>
                     <a class="jms-translation-anchor" id="{{ id }}" />
                     <p><abbr title="{{ id }}">{{ id|slice(0, 25) }}{% if id|length > 25 %}...{% endif %}</abbr></p>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | Apache2

## Description
With lager message catalogues I found myself often use the search functionality of the browser to find a key I wanted to update.

This PR introduces a text-box that allows the user to filter the message-table for keys matching the search term. Changing the language with the language-chooser will keep the filter applied on the next page.

