### PR TITLE
Use XliffLoader for format xlf instead of Symfony's loader

### DIFF
--- a/DependencyInjection/Compiler/MountLoadersPass.php
+++ b/DependencyInjection/Compiler/MountLoadersPass.php
@@ -46,12 +46,14 @@ class MountLoadersPass implements CompilerPassInterface
             $loaders[$attr[0]['alias']] = new Reference($id);
         }
 
-        foreach ($container->findTaggedServiceIds('jms_translation.loader') as $id => $attr) {
-            if (!isset($attr[0]['format'])) {
-                throw new RuntimeException(sprintf('The attribute "format" must be defined for tag "jms_translation.loader" for service "%s".', $id));
-            }
+        foreach ($container->findTaggedServiceIds('jms_translation.loader') as $id => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['format'])) {
+                    throw new RuntimeException(sprintf('The attribute "format" must be defined for tag "jms_translation.loader" for service "%s".', $id));
+                }
 
-            $loaders[$attr[0]['format']] = new Reference($id);
+                $loaders[$tag['format']] = new Reference($id);
+            }
         }
 
         $container

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -54,6 +54,7 @@
         <service id="jms_translation.loader_manager" class="%jms_translation.loader_manager.class%" /><!-- public as needed by the TranslateController -->
         <service id="jms_translation.loader.xliff_loader" class="%jms_translation.loader.xliff_loader.class%" public="false">
             <tag name="jms_translation.loader" format="xliff" />
+            <tag name="jms_translation.loader" format="xlf" />
         </service>
 
         <!-- Dumpers -->

--- a/Tests/DependencyInjection/Compiler/MountLoadersPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MountLoadersPassTest.php
@@ -28,6 +28,7 @@ class MountLoadersPassTest extends AbstractCompilerPassTestCase
 
         $collectedService = new Definition();
         $collectedService->addTag('jms_translation.loader', array('format' => 'foo'));
+        $collectedService->addTag('jms_translation.loader', array('format' => 'bar'));
         $this->setDefinition('service0', $collectedService);
 
         $this->compile();
@@ -35,7 +36,10 @@ class MountLoadersPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             'jms_translation.loader_manager',
             0,
-            array('foo' => new Reference('service0'))
+            array(
+                'foo' => new Reference('service0'),
+                'bar' => new Reference('service0'),
+            )
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2

## Description
The bundle's XliffLoader was only used if format was xliff, but not xlf. For xlf Symfony's loader was used instead. This resulted in lost attributes.