### PR TITLE
Avoid method call on null in FormExtractor

### DIFF
--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -355,7 +355,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
             $docComment = $item->key->getDocComment();
         }
 
-        if (!$docComment) {
+        if (!$docComment && $item->value) {
             $docComment = $item->value->getDocComment();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2

## Description
Avoid method call on null in FormExtractor.