### PR TITLE
Remove dependency on JMSDiExtraBundle

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### 1.3.2 to UNRELEASED
+* Remove dependencies on JMSDiExtraBundle and JMSAopBundle. If you do not use these bundles elsewhere in your application you will need to remove the reference to them in `registerBundles` of your `AppKernel` 
 
 ### 1.3.1 to 1.3.2
 * Added configuration options to disable date/sources in xliff dump

--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -28,7 +28,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @Route("/api")
+ * @Route("/api", service="jms_translation.controller.api_controller")
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */

--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -23,7 +23,6 @@ use JMS\TranslationBundle\Translation\ConfigFactory;
 use JMS\TranslationBundle\Translation\Updater;
 use Symfony\Component\HttpFoundation\Response;
 use JMS\TranslationBundle\Util\FileUtils;
-use JMS\DiExtraBundle\Annotation as DI;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
@@ -36,16 +35,26 @@ use Symfony\Component\HttpFoundation\Request;
 class ApiController
 {
     /**
-     * @DI\Inject("jms_translation.config_factory")
      * @var ConfigFactory
      */
     private $configFactory;
 
     /**
-     * @DI\Inject("jms_translation.updater")
      * @var Updater
      */
     private $updater;
+
+    /**
+     * ApiController constructor.
+     *
+     * @param ConfigFactory $configFactory
+     * @param Updater       $updater
+     */
+    public function __construct(ConfigFactory $configFactory, Updater $updater)
+    {
+        $this->configFactory = $configFactory;
+        $this->updater = $updater;
+    }
 
     /**
      * @Route("/configs/{config}/domains/{domain}/locales/{locale}/messages",

--- a/Controller/TranslateController.php
+++ b/Controller/TranslateController.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Translate Controller.
  *
+ * @Route(service="jms_translation.controller.translate_controller")
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 class TranslateController

--- a/Controller/TranslateController.php
+++ b/Controller/TranslateController.php
@@ -22,11 +22,9 @@ use JMS\TranslationBundle\Exception\RuntimeException;
 use JMS\TranslationBundle\Translation\ConfigFactory;
 use JMS\TranslationBundle\Translation\LoaderManager;
 use JMS\TranslationBundle\Util\FileUtils;
-use JMS\DiExtraBundle\Annotation as DI;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Translation\MessageCatalogue;
 
 /**
  * Translate Controller.
@@ -36,22 +34,39 @@ use Symfony\Component\Translation\MessageCatalogue;
 class TranslateController
 {
     /**
-     * @DI\Inject("jms_translation.config_factory")
      * @var ConfigFactory
      */
     private $configFactory;
 
     /**
-     * @DI\Inject("jms_translation.loader_manager")
      * @var LoaderManager
      */
     private $loader;
 
     /**
-     * @DI\Inject("%jms_translation.source_language%")
      * @var string
      */
     private $sourceLanguage;
+
+    /**
+     * TranslateController constructor.
+     *
+     * @param ConfigFactory $configFactory
+     * @param LoaderManager $loader
+     */
+    public function __construct(ConfigFactory $configFactory, LoaderManager $loader)
+    {
+        $this->configFactory = $configFactory;
+        $this->loader = $loader;
+    }
+
+    /**
+     * @param string $lang
+     */
+    public function setSourceLanguage($lang)
+    {
+        $this->sourceLanguage = $lang;
+    }
 
     /**
      * @Route("/", name="jms_translation_index", options = {"i18n" = false})

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,6 +7,9 @@
     <parameters>
         <parameter key="jms_translation.twig_extension.class">JMS\TranslationBundle\Twig\TranslationExtension</parameter>
 
+        <parameter key="jms_translation.controller.translate_controller.class">JMS\TranslationBundle\Controller\TranslateController</parameter>
+        <parameter key="jms_translation.controller.api_controller.class">JMS\TranslationBundle\Controller\ApiController</parameter>
+
         <parameter key="jms_translation.extractor_manager.class">JMS\TranslationBundle\Translation\ExtractorManager</parameter>
         <parameter key="jms_translation.extractor.file_extractor.class">JMS\TranslationBundle\Translation\Extractor\FileExtractor</parameter>
         <parameter key="jms_translation.extractor.file.default_php_extractor">JMS\TranslationBundle\Translation\Extractor\File\DefaultPhpFileExtractor</parameter>
@@ -34,6 +37,20 @@
     </parameters>
 
     <services>
+        <!-- Controllers -->
+        <service id="jms_translation.controller.translate_controller" class="%jms_translation.controller.translate_controller.class%">
+            <argument type="service" id="jms_translation.config_factory"/>
+            <argument type="service" id="jms_translation.loader_manager"/>
+            <call method="setSourceLanguage">
+                <argument>%jms_translation.source_language%</argument>
+            </call>
+        </service>
+        <service id="jms_translation.controller.api_controller" class="%jms_translation.controller.api_controller.class%">
+            <argument id="jms_translation.config_factory" type="service"/>
+            <argument id="jms_translation.updater" type="service"/>
+        </service>
+
+
         <service id="jms_translation.updater" class="%jms_translation.updater.class%">
             <argument type="service" id="jms_translation.loader_manager" />
             <argument type="service" id="jms_translation.extractor_manager" />

--- a/Resources/doc/webinterface.rst
+++ b/Resources/doc/webinterface.rst
@@ -19,9 +19,6 @@ that you need to have the SensioFrameworkExtraBundle_ installed)::
         type:     annotation
         prefix:   /_trans
 
-This bundle also requires the JMSDiExtraBundle_ for annotation-based
-dependency injection for controllers.
-
 Usage
 -----
 If you have followed the instructions above, you can now access the interface

--- a/Tests/Functional/AppKernel.php
+++ b/Tests/Functional/AppKernel.php
@@ -51,8 +51,6 @@ class AppKernel extends Kernel
             new \Symfony\Bundle\TwigBundle\TwigBundle(),
             new \JMS\TranslationBundle\JMSTranslationBundle(),
             new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
-            new \JMS\DiExtraBundle\JMSDiExtraBundle($this),
-            new \JMS\AopBundle\JMSAopBundle(),
         );
     }
 

--- a/Tests/Functional/Fixture/TestBundle/Controller/AppleController.php
+++ b/Tests/Functional/Fixture/TestBundle/Controller/AppleController.php
@@ -2,8 +2,6 @@
 
 namespace JMS\TranslationBundle\Tests\Functional\Fixture\TestBundle\Controller;
 
-use JMS\DiExtraBundle\Annotation as DI;
-use JMS\SecurityExtraBundle\Annotation\PreAuthorize;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "symfony/symfony": "^2.3 || ^3.0",
         "symfony/expression-language": "^2.6 || ^3.0",
         "sensio/framework-extra-bundle": "^2.3 || ^3.0",
-        "jms/di-extra-bundle": "^1.1",
         "nyholm/nsa": "^1.0.1",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | no
| BC breaks?    | yes (extremely minor, requires removing two lines from `AppKernel` for some users)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | closes #355, closes #411, closes #457
| License       | Apache2


## Description
This is an updated version of https://github.com/schmittjoh/JMSTranslationBundle/pull/411. I have rebased in on to the latest master, updated it to get the tests passing and updated the docs and changelog as appropriate.

The BC break is only going to affect users that have added the DiExtraBundle and AopBundle to their `AppKernel` file. We can avoid it altogether by continuing to keep the DiExtraBundle as a dependency in `composer.json` until a 2.0 release. It's an extremely trivial BC break that will be notified to users when the post install scripts are executed during composer update so I'm inclined to say it can be merged as is.

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog
