### PR TITLE
Add missing Symfony validator dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "twig/twig": "^1.27 || ^2.0",
         "symfony/framework-bundle": "^2.3 || ^3.0",
         "nikic/php-parser": "^1.4 || ^2.0 || ^3.0",
-        "symfony/console": "^2.3 || ^3.0"
+        "symfony/console": "^2.3 || ^3.0",
+        "symfony/validator": "^2.3 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.27",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | Apache2


## Description
This bundle has a strict dependency on Symfony Validator here:
https://github.com/schmittjoh/JMSTranslationBundle/blob/c837dc6276e99e95e5bdbfb9190e2d595642ba63/Resources/config/services.xml#L122

## Todos
- [ ] Update composer.lock file as well