### PR TITLE
Fix #474 Unable to find template @JMSTranslation/translate/index.html.twig

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### 1.3.2 to UNRELEASED
+* Fixed "Unable to find template @JMSTranslation/translate/index.html.twig"
 
 ### 1.3.1 to 1.3.2
 * Added configuration options to disable date/sources in xliff dump

--- a/Controller/TranslateController.php
+++ b/Controller/TranslateController.php
@@ -55,7 +55,7 @@ class TranslateController
 
     /**
      * @Route("/", name="jms_translation_index", options = {"i18n" = false})
-     * @Template
+     * @Template("JMSTranslationBundle:Translate:index.html.twig")
      * @param Request $request
      * @return array
      */


### PR DESCRIPTION
Set template name in TranslateController:indexAction


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #474 
| License       | Apache2


## Description
Make  Web UI Translations working

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog
