### PR TITLE
Manage legacy aliases if exist

### DIFF
--- a/DependencyInjection/Compiler/MountLoadersPass.php
+++ b/DependencyInjection/Compiler/MountLoadersPass.php
@@ -44,6 +44,9 @@ class MountLoadersPass implements CompilerPassInterface
             $container->setDefinition($id = 'jms_translation.loader.wrapped_symfony_loader.'.($i++), $def);
 
             $loaders[$attr[0]['alias']] = new Reference($id);
+            if (isset($attr[0]['legacy_alias'])) {
+                $loaders[$attr[0]['legacy_alias']] = new Reference($id);
+            }
         }
 
         foreach ($container->findTaggedServiceIds('jms_translation.loader') as $id => $attr) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #468
| License       | Apache2


## Description

This fix the issue with `.yml` file for Symfony 3.4 using `legacy_alias`:

```
Information for Service "translation.loader.yml"
================================================

 ---------------- ------------------------------------------------------------------------ 
  Option           Value                                                                   
 ---------------- ------------------------------------------------------------------------ 
  Service ID       translation.loader.yml                                                  
  Class            Symfony\Component\Translation\Loader\YamlFileLoader                     
  Tags             translation.loader (alias: yaml, legacy_alias: yml, legacy-alias: yml)  
  Public           yes                                                                     
  Synthetic        no                                                                      
  Lazy             no                                                                      
  Shared           yes                                                                     
  Abstract         no                                                                      
  Autowired        no                                                                      
  Autoconfigured   no                                                                      
 ---------------- ------------------------------------------------------------------------ 
```
