### PR TITLE
 Auto-registration of the command

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -166,11 +166,12 @@
         </service>
         
         <!-- Command -->
-        <service id="JMS\TranslationBundle\Command\ExtractTranslationCommand">
+        <!-- Command -->
+        <service id="JMS\TranslationBundle\Command\ExtractTranslationCommand" class="JMS\TranslationBundle\Command\ExtractTranslationCommand">
             <tag name="console.command" command="translation:extract" />
         </service>
         
-        <service id="JMS\TranslationBundle\Command\ResourcesListCommand">
+        <service id="JMS\TranslationBundle\Command\ResourcesListCommand" class="JMS\TranslationBundle\Command\ResourcesListCommand">
             <tag name="console.command" command="translation:list-resources" />
         </service>
         

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -164,5 +164,15 @@
             <argument>%kernel.debug%</argument>
             <tag name="twig.extension" />
         </service>
+        
+        <!-- Command -->
+        <service id="JMS\TranslationBundle\Command\ExtractTranslationCommand">
+            <tag name="console.command" command="translation:extract" />
+        </service>
+        
+        <service id="JMS\TranslationBundle\Command\ResourcesListCommand">
+            <tag name="console.command" command="translation:list-resources" />
+        </service>
+        
     </services>
 </container>


### PR DESCRIPTION
Deprecated since Symfony 3.4 and won't be supported in 4.0. Use PSR-4 based service discovery instead.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
A few sentences describing the overall goals of the pull request's commits.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
