### PR TITLE
Remove deprecated target-dir usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,8 @@
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6"
     },
     "autoload": {
-        "psr-0": { "JMS\\TranslationBundle": "" }
+        "psr-4": { "JMS\\TranslationBundle\\": "" }
     },
-    "target-dir": "JMS/TranslationBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "1.4-dev"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


Ref: https://getcomposer.org/doc/04-schema.md#target-dir

See also: https://github.com/maglnet/ComposerRequireChecker/issues/55

Could you please push a patch release after merging this one?