### PR TITLE
Fixed pattern setting in FileExtractor #483

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### 1.3.2 to UNRELEASED
 * Remove dependencies on JMSDiExtraBundle and JMSAopBundle. If you do not use these bundles elsewhere in your application you will need to remove the reference to them in `registerBundles` of your `AppKernel` 
+* Fixed pattern setting in ```FileExtractor```, it now passes all its values into ```Finder::name``` method
+  - Added new, properly named setter ```setPatterns(array $patterns)```
+  - Deprecated old setter ```setPattern```
 
 ### 1.3.1 to 1.3.2
 * Added configuration options to disable date/sources in xliff dump

--- a/Translation/Extractor/FileExtractor.php
+++ b/Translation/Extractor/FileExtractor.php
@@ -56,7 +56,7 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
     /**
      * @var array
      */
-    private $pattern;
+    private $patterns = array();
 
     /**
      * @var string
@@ -168,11 +168,20 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
     }
 
     /**
+     * @param array $patterns
+     */
+    public function setPatterns(array $patterns)
+    {
+        $this->patterns = $patterns;
+    }
+
+    /**
      * @param array $pattern
+     * @deprecated Use setPatterns method
      */
     public function setPattern(array $pattern)
     {
-        $this->pattern = $pattern;
+        $this->patterns = $pattern;
     }
 
     /**
@@ -198,8 +207,8 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
             $finder->notName($name);
         }
 
-        if ($this->pattern) {
-            $finder->name($this->pattern);
+        foreach ($this->patterns as $pattern) {
+            $finder->name($pattern);
         }
 
         $curTwigLoader = $this->twig->getLoader();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #483 
| License       | Apache2


## Description
Fixes #483 - Pattern setting in FileExtractor now properly processes arrays as it should.

## Todos
- [x] Changelog
