### PR TITLE
Use explicit template name

### DIFF
--- a/Controller/TranslateController.php
+++ b/Controller/TranslateController.php
@@ -71,7 +71,7 @@ class TranslateController
 
     /**
      * @Route("/", name="jms_translation_index", options = {"i18n" = false})
-     * @Template
+     * @Template(template="@JMSTranslation/Translate/index.html.twig")
      * @param Request $request
      * @return array
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes and no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | Apache2

This https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/508 change in the v4 of SensioFrameworkExtraBundle changed the behaviour of the `@Template` annotation by lowercasing the controller name... this caused https://github.com/symfony/symfony-standard/issues/1126 and on the translator bundle cases `Unable to find template "@JMSTranslation/translate/index.html.twig" (looked into: /app/vendor/jms/translation-bundle/JMS/TranslationBundle/Resources/views).`