### PR TITLE
Fix nikic/php-parser v4 compatibility

### DIFF
--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -116,9 +116,12 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
      */
     public function enterNode(Node $node)
     {
-        if (!$node instanceof Node\Expr\MethodCall
-            || !is_string($node->name)
-            || !in_array(strtolower($node->name), array_map('strtolower', array_keys($this->methodsToExtractFrom)))) {
+        $methodCallNodeName = null;
+        if ($node instanceof Node\Expr\MethodCall) {
+            $methodCallNodeName = $node->name instanceof Node\Identifier ? $node->name->name : $node->name;
+        }
+        if (!is_string($methodCallNodeName)
+            || !in_array(strtolower($methodCallNodeName), array_map('strtolower', array_keys($this->methodsToExtractFrom)))) {
             $this->previousNode = $node;
             return;
         }
@@ -157,7 +160,7 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
 
         $id = $node->args[0]->value->value;
 
-        $index = $this->methodsToExtractFrom[strtolower($node->name)];
+        $index = $this->methodsToExtractFrom[strtolower($methodCallNodeName)];
         if (isset($node->args[$index])) {
             if (!$node->args[$index]->value instanceof String_) {
                 if ($ignore) {

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -102,11 +102,12 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
         }
 
         if ($node instanceof Node\Expr\MethodCall) {
-            if (!is_string($node->name)) {
+            $nodeName = $node->name instanceof Node\Identifier ? $node->name->name : $node->name;
+            if (!is_string($nodeName)) {
                 return;
             }
 
-            $name = strtolower($node->name);
+            $name = strtolower($nodeName);
             if ('setdefaults' === $name || 'replacedefaults' === $name || 'setdefault' === $name) {
                 $this->parseDefaultsCall($node);
                 return;

--- a/Translation/Extractor/File/TranslationContainerExtractor.php
+++ b/Translation/Extractor/File/TranslationContainerExtractor.php
@@ -86,7 +86,8 @@ class TranslationContainerExtractor implements FileVisitorInterface, NodeVisitor
         }
 
         if ($node instanceof Node\Stmt\UseUse) {
-            $this->useStatements[$node->alias] = implode('\\', $node->name->parts);
+            $nodeAliasName = is_string($node->alias) ? $node->alias : $node->getAlias()->name;
+            $this->useStatements[$nodeAliasName] = implode('\\', $node->name->parts);
 
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | Apache2

Closes #485 
Closes #476 

## Description

#477 introduces some bug with nikic/php-parser v4.

I fixed most of them, but I'm currently stuck for the form extractor.

The issue seems to be the `Class_` node statement does not have anything more on it `implements` property, and the interface implement detection does not work: https://github.com/schmittjoh/JMSTranslationBundle/blob/master/Translation/Extractor/File/TranslationContainerExtractor.php#L99-L109

I can't figure out why for now, help would be appreciated.

I also let the PR editable for the maintainers. :+1: 

## Todos
- [x] Tests fix
