### PR TITLE
Remove usage of deprecated code from SensioFrameworkExtraBundle

### DIFF
--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -21,11 +21,11 @@ namespace JMS\TranslationBundle\Controller;
 use JMS\TranslationBundle\Exception\RuntimeException;
 use JMS\TranslationBundle\Translation\ConfigFactory;
 use JMS\TranslationBundle\Translation\Updater;
-use Symfony\Component\HttpFoundation\Response;
 use JMS\TranslationBundle\Util\FileUtils;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Method;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @Route("/api", service="jms_translation.controller.api_controller")

--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -22,10 +22,9 @@ use JMS\TranslationBundle\Exception\RuntimeException;
 use JMS\TranslationBundle\Translation\ConfigFactory;
 use JMS\TranslationBundle\Translation\Updater;
 use JMS\TranslationBundle\Util\FileUtils;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Method;
-use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @Route("/api", service="jms_translation.controller.api_controller")
@@ -57,11 +56,14 @@ class ApiController
     }
 
     /**
-     * @Route("/configs/{config}/domains/{domain}/locales/{locale}/messages",
-     *            name="jms_translation_update_message",
-     *            defaults = {"id" = null},
-     *            options = {"i18n" = false})
-     * @Method("PUT")
+     * @Route(
+     *     "/configs/{config}/domains/{domain}/locales/{locale}/messages",
+     *     name="jms_translation_update_message",
+     *     methods = {"PUT"},
+     *     defaults = {"id" = null},
+     *     options = {"i18n" = false}
+     * )
+     *
      * @param Request $request
      * @param string $config
      * @param string $domain

--- a/Controller/TranslateController.php
+++ b/Controller/TranslateController.php
@@ -22,8 +22,8 @@ use JMS\TranslationBundle\Exception\RuntimeException;
 use JMS\TranslationBundle\Translation\ConfigFactory;
 use JMS\TranslationBundle\Translation\LoaderManager;
 use JMS\TranslationBundle\Util\FileUtils;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/Tests/Functional/TranslationTest.php
+++ b/Tests/Functional/TranslationTest.php
@@ -2,15 +2,26 @@
 
 namespace JMS\TranslationBundle\Tests\Functional;
 
+use Symfony\Component\HttpKernel\Kernel;
+
 class TranslationTest extends BaseTestCase
 {
     public function testTranschoiceWhenTranslationNotYetExtracted()
     {
-        $client = $this->createClient();
+        $isSf4 = version_compare(Kernel::VERSION,'4.0.0') >= 0;
+
+        // Add a file
+        $file = $isSf4 ? __DIR__.'/Fixture/TestBundle/Resources/translations/navigation.en.yaml' : __DIR__.'/Fixture/TestBundle/Resources/translations/navigation.en.yml';
+        file_put_contents($file, '');
+
+        $client = static::createClient();
         $client->request('GET', '/apples/view');
-	$response = $client->getResponse();
+	    $response = $client->getResponse();
 
         $this->assertEquals(200, $response->getStatusCode(), substr($response, 0, 2000));
         $this->assertEquals("There are 5 apples\n\nThere are 5 apples", $response->getContent());
+
+        // Remove the file
+        unlink($file);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
     "require": {
         "php": "^5.3.3 || ^7.0",
         "twig/twig": "^1.27 || ^2.0",
-        "symfony/framework-bundle": "^2.3 || ^3.0 || ^4.0",
         "nikic/php-parser": "^1.4 || ^2.0 || ^3.0 || ^4.0",
-        "symfony/console": "^2.3 || ^3.0 || ^4.0",
-        "symfony/validator": "^2.3 || ^3.0 || ^4.0"
+        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",
+        "symfony/console": "^2.8 || ^3.0 || ^4.0",
+        "symfony/validator": "^2.8 || ^3.0 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.0",
+        "phpunit/phpunit": "^5.0 || ^6.0",
         "psr/log": "^1.0",
-        "symfony/symfony": "^2.3 || ^3.0 || ^4.0",
-        "symfony/expression-language": "^2.6 || ^3.0 || ^4.0",
-        "sensio/framework-extra-bundle": "^2.3 || ^3.0 || ^4.0",
+        "symfony/symfony": "^2.8 || ^3.0 || ^4.0",
+        "symfony/expression-language": "^2.8 || ^3.0 || ^4.0",
+        "sensio/framework-extra-bundle": "^2.8 || ^3.0 || ^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.2",
         "nyholm/nsa": "^1.0.1"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes(?)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no (removal)
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
Those two classes will be removed & now they generate such warnings:
```
The "Sensio\Bundle\FrameworkExtraBundle\Configuration\Route" annotation is deprecated since version 5.2. Use "Symfony\Component\Routing\Annotation\Route" instead.
The "Sensio\Bundle\FrameworkExtraBundle\Configuration\Method" annotation is deprecated since version 5.2. Use "Symfony\Component\Routing\Annotation\Route" instead.
```
