### PR TITLE
Test if filter exists before use

### DIFF
--- a/Resources/public/js/jms.js
+++ b/Resources/public/js/jms.js
@@ -211,11 +211,22 @@ function JMSTranslationManager(updateMessagePath, isWritable)
             $(JMS.messageFilter.selector).val(window.location.hash.substr(1));
         },
         filter: function () {
-            var filterString = $(JMS.messageFilter.selector).val().trim().replace(/[-[\]{}()+?,\\^$|#\s]/g, "\\$&");
+            var filter = $(JMS.messageFilter.selector);
+            var messageRow = $(".messageRow");
+
+            if (filter.length === 0) {
+                messageRow.each(function () {
+                    $(this).show();
+                });
+
+                return;
+            }
+
+            var filterString = filter.val().trim().replace(/[-[\]{}()+?,\\^$|#\s]/g, "\\$&");
             var regExp = new RegExp(".*" + filterString + ".*", "i");
             window.location.hash = filterString;
             if (filterString !== "") {
-                $(".messageRow").each(function () {
+                messageRow.each(function () {
                     var id = this.id.substr(4);
                     if (id.match(regExp)) {
                         $(this).show();
@@ -223,12 +234,12 @@ function JMSTranslationManager(updateMessagePath, isWritable)
                         $(this).hide();
                     }
                 });
-
-            } else {
-                $(".messageRow").each(function () {
-                    $(this).show();
-                });
+                return ;
             }
+
+            messageRow.each(function () {
+                $(this).show();
+            });
         }
     };
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
The jms.js has a bug where if no html element named '#filter' it will cause a fatal error. This tests if the filter exists first before trying to use it.

