### PR TITLE
Remove deprecated usage of ContainerAwareCommand, replace by DI

### DIFF
--- a/Command/ExtractTranslationCommand.php
+++ b/Command/ExtractTranslationCommand.php
@@ -19,22 +19,47 @@
 namespace JMS\TranslationBundle\Command;
 
 use JMS\TranslationBundle\Translation\ConfigBuilder;
-use JMS\TranslationBundle\Exception\RuntimeException;
+use JMS\TranslationBundle\Translation\ConfigFactory;
+use JMS\TranslationBundle\Translation\Updater;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
-use JMS\TranslationBundle\Translation\Config;
 use JMS\TranslationBundle\Logger\OutputLogger;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\DependencyInjection\Container;
 
 /**
  * Command for extracting translations.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class ExtractTranslationCommand extends ContainerAwareCommand
+class ExtractTranslationCommand extends Command
 {
+    /**
+     * @var ConfigFactory
+     */
+    private $configFactory;
+
+    /**
+     * @var Updater
+     */
+    private $updater;
+
+    /**
+     * @var array
+     */
+    private $locales;
+
+    public function __construct(ConfigFactory $configFactory, Updater $updater, $locales)
+    {
+        parent::__construct();
+        $this->configFactory = $configFactory;
+        $this->updater = $updater;
+        $this->locales = $locales;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -70,14 +95,14 @@ class ExtractTranslationCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $builder = $input->getOption('config') ?
-                       $this->getContainer()->get('jms_translation.config_factory')->getBuilder($input->getOption('config'))
+                       $this->configFactory->getBuilder($input->getOption('config'))
                        : new ConfigBuilder();
 
         $this->updateWithInput($input, $builder);
 
         $locales = $input->getArgument('locales');
         if (empty($locales)) {
-            $locales = $this->getContainer()->getParameter('jms_translation.locales');
+            $locales = $this->locales;
         }
 
         if (empty($locales)) {
@@ -97,15 +122,14 @@ class ExtractTranslationCommand extends ContainerAwareCommand
             $output->writeln(sprintf('Custom Extractors: <info>%s</info>', $config->getEnabledExtractors() ? implode(', ', array_keys($config->getEnabledExtractors())) : '# none #'));
             $output->writeln('============================================================');
 
-            $updater = $this->getContainer()->get('jms_translation.updater');
-            $updater->setLogger($logger = new OutputLogger($output));
+            $this->updater->setLogger($logger = new OutputLogger($output));
 
             if (!$input->getOption('verbose')) {
                 $logger->setLevel(OutputLogger::ALL ^ OutputLogger::DEBUG);
             }
 
             if ($input->getOption('dry-run')) {
-                $changeSet = $updater->getChangeSet($config);
+                $changeSet = $this->updater->getChangeSet($config);
 
                 $output->writeln('Added Messages: '.count($changeSet->getAddedMessages()));
                 if ($input->hasParameterOption('--verbose')) {
@@ -128,7 +152,7 @@ class ExtractTranslationCommand extends ContainerAwareCommand
                 return;
             }
 
-            $updater->process($config);
+            $this->updater->process($config);
         }
 
         $output->writeln('done!');

--- a/Command/ResourcesListCommand.php
+++ b/Command/ResourcesListCommand.php
@@ -22,6 +22,7 @@ use JMS\TranslationBundle\Translation\ConfigBuilder;
 use JMS\TranslationBundle\Exception\RuntimeException;
 use JMS\TranslationBundle\Translation\Config;
 use JMS\TranslationBundle\Logger\OutputLogger;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -34,8 +35,25 @@ use JMS\TranslationBundle\Util\FileUtils;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class ResourcesListCommand extends ContainerAwareCommand
+class ResourcesListCommand extends Command
 {
+    /**
+     * @var string
+     */
+    private $kernelRootDir;
+
+    /**
+     * @var array
+     */
+    private $kernelBundles;
+
+    public function __construct($kernelRootDir, $kernelBundles)
+    {
+        parent::__construct();
+        $this->kernelRootDir = $kernelRootDir;
+        $this->kernelBundles = $kernelBundles;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -55,8 +73,8 @@ class ResourcesListCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $rootPath = realpath($this->getContainer()->getParameter('kernel.root_dir'));
-        $basePath = realpath($this->getContainer()->getParameter('kernel.root_dir').'/..');
+        $rootPath = realpath($this->kernelRootDir);
+        $basePath = realpath($this->kernelRootDir.'/..');
 
         $dirs = $this->retrieveDirs();
 
@@ -113,14 +131,14 @@ class ResourcesListCommand extends ContainerAwareCommand
     {
         // Discover translation directories
         $dirs = array();
-        foreach ($this->getContainer()->getParameter('kernel.bundles') as $bundle) {
+        foreach ($this->kernelBundles as $bundle) {
             $reflection = new \ReflectionClass($bundle);
             if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/translations')) {
                 $dirs[] = $dir;
             }
         }
 
-        if (is_dir($dir = $this->getContainer()->getParameter('kernel.root_dir').'/Resources/translations')) {
+        if (is_dir($dir = $this->kernelRootDir.'/Resources/translations')) {
             $dirs[] = $dir;
         }
 

--- a/Resources/config/console.xml
+++ b/Resources/config/console.xml
@@ -6,10 +6,15 @@
 
     <services>
         <service id="jms_translation.command.extract" class="JMS\TranslationBundle\Command\ExtractTranslationCommand" public="false">
+            <argument type="service" id="jms_translation.config_factory"/>
+            <argument type="service" id="jms_translation.updater"/>
+            <argument>%jms_translation.locales%</argument>
             <tag name="console.command" command="translation:extract" />
         </service>
 
         <service id="jms_translation.command.list_resources" class="JMS\TranslationBundle\Command\ResourcesListCommand" public="false">
+            <argument>%kernel.root_dir%</argument>
+            <argument>%kernel.bundles%</argument>
             <tag name="console.command" command="translation:list-resources" />
         </service>
     </services>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description

This PR remove the usage of `Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand` and use dependency injection instead.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog
