### PR TITLE
Compile nodes before comparing them

### DIFF
--- a/Tests/Twig/BaseTwigTestCase.php
+++ b/Tests/Twig/BaseTwigTestCase.php
@@ -33,6 +33,6 @@ abstract class BaseTwigTestCase extends \PHPUnit_Framework_TestCase
         $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
         $env->addExtension(new TranslationExtension($translator, $debug));
 
-        return $env->parse($env->tokenize(new \Twig_Source($content, null)))->getNode('body');
+        return $env->compile($env->parse($env->tokenize(new \Twig_Source($content, 'whatever')))->getNode('body'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | not for the end user
| New feature?  | no
| BC breaks?    | no, only tests changes
| Deprecations? | no
| Tests pass?   | yes, that's the whole point
| Fixed tickets | 
| License       | Apache2


## Description

Not sure since when, but parsing is not enough to obtain the same code
from different fixtures.
Adding that extra step fixes the failing tests and the build.