### PR TITLE
Address namespace change in Twig

### DIFF
--- a/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
@@ -38,6 +38,8 @@ use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Translation\MessageSelector;
 use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Source;
 
 class TwigFileExtractorTest extends \PHPUnit_Framework_TestCase
 {
@@ -145,7 +147,7 @@ class TwigFileExtractorTest extends \PHPUnit_Framework_TestCase
             throw new RuntimeException(sprintf('The file "%s" does not exist.', $file));
         }
 
-        $env = new \Twig_Environment(new \Twig_Loader_Array(array()));
+        $env = new Environment(new ArrayLoader(array()));
         $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
         $env->addExtension(new TranslationExtension($translator, true));
         $env->addExtension(new RoutingExtension(new UrlGenerator(new RouteCollection(), new RequestContext())));
@@ -168,7 +170,7 @@ class TwigFileExtractorTest extends \PHPUnit_Framework_TestCase
             $extractor = new TwigFileExtractor($env, new FileSourceFactory('faux'));
         }
 
-        $ast = $env->parse($env->tokenize(new \Twig_Source(file_get_contents($file), $file)));
+        $ast = $env->parse($env->tokenize(new Source(file_get_contents($file), $file)));
 
         $catalogue = new MessageCatalogue();
         $extractor->visitTwigFile(new \SplFileInfo($file), $catalogue, $ast);

--- a/Tests/Translation/Extractor/FileExtractorTest.php
+++ b/Tests/Translation/Extractor/FileExtractorTest.php
@@ -37,6 +37,9 @@ use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExtension;
 use JMS\TranslationBundle\Translation\Extractor\FileExtractor;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Loader\FilesystemLoader;
 
 class FileExtractorTest extends \PHPUnit_Framework_TestCase
 {
@@ -95,10 +98,10 @@ class FileExtractorTest extends \PHPUnit_Framework_TestCase
 
     private function extract($directory)
     {
-        $twig = new \Twig_Environment(new \Twig_Loader_Array(array()));
+        $twig = new Environment(new ArrayLoader(array()));
         $twig->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
         $twig->addExtension(new TranslationExtension($translator));
-        $loader=new \Twig_Loader_Filesystem(realpath(__DIR__."/Fixture/SimpleTest/Resources/views/"));
+        $loader=new FilesystemLoader(realpath(__DIR__."/Fixture/SimpleTest/Resources/views/"));
         $twig->setLoader($loader);
 
         $docParser = new DocParser();

--- a/Tests/Translation/ExtractorManagerTest.php
+++ b/Tests/Translation/ExtractorManagerTest.php
@@ -24,6 +24,8 @@ use JMS\TranslationBundle\Tests\BaseTestCase;
 use Psr\Log\NullLogger;
 use JMS\TranslationBundle\Translation\Extractor\FileExtractor;
 use JMS\TranslationBundle\Translation\ExtractorManager;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 class ExtractorManagerTest extends BaseTestCase
 {
@@ -68,7 +70,7 @@ class ExtractorManagerTest extends BaseTestCase
         $foo = $this->createMock('JMS\TranslationBundle\Translation\ExtractorInterface');
         $logger = new NullLogger();
 
-        $extractor = new FileExtractor(new \Twig_Environment(new \Twig_Loader_Array(array())), $logger, array());
+        $extractor = new FileExtractor(new Environment(new ArrayLoader(array())), $logger, array());
         $extractor->setExcludedNames(array('foo', 'bar'));
         $extractor->setExcludedDirs(array('baz'));
 
@@ -111,7 +113,7 @@ class ExtractorManagerTest extends BaseTestCase
         $logger = new NullLogger();
 
         if (null === $extractor) {
-            $extractor = new FileExtractor(new \Twig_Environment(new \Twig_Loader_Array(array())), $logger, array());
+            $extractor = new FileExtractor(new Environment(new ArrayLoader(array())), $logger, array());
         }
 
         return new ExtractorManager($extractor, $logger, $extractors);

--- a/Tests/Twig/BaseTwigTestCase.php
+++ b/Tests/Twig/BaseTwigTestCase.php
@@ -22,6 +22,9 @@ use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExtension;
 use JMS\TranslationBundle\Twig\TranslationExtension;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Source;
 
 abstract class BaseTwigTestCase extends \PHPUnit_Framework_TestCase
 {
@@ -29,10 +32,10 @@ abstract class BaseTwigTestCase extends \PHPUnit_Framework_TestCase
     {
         $content = file_get_contents(__DIR__.'/Fixture/'.$file);
 
-        $env = new \Twig_Environment(new \Twig_Loader_Array(array()));
+        $env = new Environment(new ArrayLoader(array()));
         $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
         $env->addExtension(new TranslationExtension($translator, $debug));
 
-        return $env->compile($env->parse($env->tokenize(new \Twig_Source($content, 'whatever')))->getNode('body'));
+        return $env->compile($env->parse($env->tokenize(new Source($content, 'whatever')))->getNode('body'));
     }
 }

--- a/Translation/Extractor/File/AuthenticationMessagesExtractor.php
+++ b/Translation/Extractor/File/AuthenticationMessagesExtractor.php
@@ -32,6 +32,7 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use Psr\Log\LoggerInterface;
+use Twig\Node\Node as TwigNode;
 
 class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisitorInterface, NodeVisitor
 {
@@ -266,9 +267,9 @@ class AuthenticationMessagesExtractor implements LoggerAwareInterface, FileVisit
     /**
      * @param \SplFileInfo $file
      * @param MessageCatalogue $catalogue
-     * @param \Twig_Node $ast
+     * @param TwigNode $ast
      */
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
     }
 }

--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -34,6 +34,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PhpParser\Node\Scalar\String_;
 use Psr\Log\LoggerInterface;
+use Twig\Node\Node as TwigNode;
 
 /**
  * This parser can extract translation information from PHP files.
@@ -236,9 +237,8 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
     /**
      * @param \SplFileInfo $file
      * @param MessageCatalogue $catalogue
-     * @param \Twig_Node $ast
      */
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
     }
 

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -34,6 +34,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Kernel;
+use Twig\Node\Node as TwigNode;
 
 class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeVisitor
 {
@@ -491,9 +492,9 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
     /**
      * @param \SplFileInfo $file
      * @param MessageCatalogue $catalogue
-     * @param \Twig_Node $ast
+     * @param TwigNode $ast
      */
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
     }
 

--- a/Translation/Extractor/File/TranslationContainerExtractor.php
+++ b/Translation/Extractor/File/TranslationContainerExtractor.php
@@ -25,6 +25,7 @@ use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
+use Twig\Node\Node as TwigNode;
 
 /**
  * Extracts translations from designated translation containers.
@@ -174,9 +175,8 @@ class TranslationContainerExtractor implements FileVisitorInterface, NodeVisitor
     /**
      * @param \SplFileInfo $file
      * @param MessageCatalogue $catalogue
-     * @param \Twig_Node $ast
      */
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
     }
 }

--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -24,8 +24,14 @@ use Symfony\Bridge\Twig\Node\TransNode;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use Twig\Environment;
+use Twig\NodeTraverser;
+use Twig\NodeVisitor\AbstractNodeVisitor;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\FilterExpression;
+use Twig\Node\Node;
 
-class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInterface
+class TwigFileExtractor extends AbstractNodeVisitor implements FileVisitorInterface
 {
     /**
      * @var FileSourceFactory
@@ -43,7 +49,7 @@ class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInte
     private $catalogue;
 
     /**
-     * @var \Twig_NodeTraverser
+     * @var NodeTraverser
      */
     private $traverser;
 
@@ -54,21 +60,19 @@ class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInte
 
     /**
      * TwigFileExtractor constructor.
-     * @param \Twig_Environment $env
+     * @param Environment $env
      * @param FileSourceFactory $fileSourceFactory
      */
-    public function __construct(\Twig_Environment $env, FileSourceFactory $fileSourceFactory)
+    public function __construct(Environment $env, FileSourceFactory $fileSourceFactory)
     {
         $this->fileSourceFactory = $fileSourceFactory;
-        $this->traverser = new \Twig_NodeTraverser($env, array($this));
+        $this->traverser = new NodeTraverser($env, array($this));
     }
 
     /**
-     * @param \Twig_Node $node
-     * @param \Twig_Environment $env
-     * @return \Twig_Node
+     * @return Node
      */
-    protected function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doEnterNode(Node $node, Environment $env)
     {
         $this->stack[] = $node;
 
@@ -83,12 +87,12 @@ class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInte
             $message = new Message($id, $domain);
             $message->addSource($this->fileSourceFactory->create($this->file, $node->getTemplateLine()));
             $this->catalogue->add($message);
-        } elseif ($node instanceof \Twig_Node_Expression_Filter) {
+        } elseif ($node instanceof FilterExpression) {
             $name = $node->getNode('filter')->getAttribute('value');
 
             if ('trans' === $name || 'transchoice' === $name) {
                 $idNode = $node->getNode('node');
-                if (!$idNode instanceof \Twig_Node_Expression_Constant) {
+                if (!$idNode instanceof ConstantExpression) {
                     return $node;
                     // FIXME: see below
 //                     throw new \RuntimeException(sprintf('Cannot infer translation id from node "%s". Please refactor to only translate constants.', get_class($idNode)));
@@ -100,7 +104,7 @@ class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInte
                 $arguments = $node->getNode('arguments');
                 if ($arguments->hasNode($index)) {
                     $argument = $arguments->getNode($index);
-                    if (!$argument instanceof \Twig_Node_Expression_Constant) {
+                    if (!$argument instanceof ConstantExpression) {
                         return $node;
                         // FIXME: Throw exception if there is some way for the user to turn this off
                         //        on a case-by-case basis, similar to @Ignore in PHP
@@ -113,7 +117,7 @@ class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInte
                 $message->addSource($this->fileSourceFactory->create($this->file, $node->getTemplateLine()));
 
                 for ($i=count($this->stack)-2; $i>=0; $i-=1) {
-                    if (!$this->stack[$i] instanceof \Twig_Node_Expression_Filter) {
+                    if (!$this->stack[$i] instanceof FilterExpression) {
                         break;
                     }
 
@@ -125,7 +129,7 @@ class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInte
                         }
 
                         $text = $arguments->getNode(0);
-                        if (!$text instanceof \Twig_Node_Expression_Constant) {
+                        if (!$text instanceof ConstantExpression) {
                             throw new RuntimeException(sprintf('The first argument of the "%s" filter must be a constant expression, such as a string.', $name));
                         }
 
@@ -153,9 +157,8 @@ class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInte
     /**
      * @param \SplFileInfo $file
      * @param MessageCatalogue $catalogue
-     * @param \Twig_Node $ast
      */
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, Node $ast)
     {
         $this->file = $file;
         $this->catalogue = $catalogue;
@@ -167,10 +170,8 @@ class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInte
      * If the current Twig Node has embedded templates, we want to travese these templates
      * in the same manner as we do the main twig template to ensure all translations are
      * caught.
-     *
-     * @param \Twig_Node $node
      */
-    private function traverseEmbeddedTemplates(\Twig_Node $node)
+    private function traverseEmbeddedTemplates(Node $node)
     {
         $templates = $node->getAttribute('embedded_templates');
 
@@ -183,11 +184,9 @@ class TwigFileExtractor extends \Twig_BaseNodeVisitor implements FileVisitorInte
     }
 
     /**
-     * @param \Twig_Node $node
-     * @param \Twig_Environment $env
-     * @return \Twig_Node
+     * @return Node
      */
-    protected function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doLeaveNode(Node $node, Environment $env)
     {
         array_pop($this->stack);
 

--- a/Translation/Extractor/File/ValidationExtractor.php
+++ b/Translation/Extractor/File/ValidationExtractor.php
@@ -27,6 +27,7 @@ use Symfony\Component\Validator\MetadataFactoryInterface as LegacyMetadataFactor
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use Twig\Node\Node as TwigNode;
 
 /**
  * Extracts translations validation constraints.
@@ -164,9 +165,8 @@ class ValidationExtractor implements FileVisitorInterface, NodeVisitor
     /**
      * @param \SplFileInfo $file
      * @param MessageCatalogue $catalogue
-     * @param \Twig_Node $ast
      */
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
     }
 

--- a/Translation/Extractor/FileExtractor.php
+++ b/Translation/Extractor/FileExtractor.php
@@ -30,6 +30,10 @@ use JMS\TranslationBundle\Twig\RemovingNodeVisitor;
 use JMS\TranslationBundle\Translation\ExtractorInterface;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use Symfony\Component\Finder\Finder;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\NodeVisitor\NodeVisitorInterface;
+use Twig\Source;
 
 /**
  * File-based extractor.
@@ -39,7 +43,7 @@ use Symfony\Component\Finder\Finder;
 class FileExtractor implements ExtractorInterface, LoggerAwareInterface
 {
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -64,12 +68,12 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
     private $directory;
 
     /**
-     * @var RemovingNodeVisitor|\Twig_NodeVisitorInterface
+     * @var RemovingNodeVisitor|NodeVisitorInterface
      */
     private $removingTwigVisitor;
 
     /**
-     * @var DefaultApplyingNodeVisitor|RemovingNodeVisitor|\Twig_NodeVisitorInterface
+     * @var DefaultApplyingNodeVisitor|RemovingNodeVisitor|NodeVisitorInterface
      */
     private $defaultApplyingTwigVisitor;
 
@@ -90,11 +94,11 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
 
     /**
      * FileExtractor constructor.
-     * @param \Twig_Environment $twig
+     * @param Environment $twig
      * @param LoggerInterface $logger
      * @param array $visitors
      */
-    public function __construct(\Twig_Environment $twig, LoggerInterface $logger, array $visitors)
+    public function __construct(Environment $twig, LoggerInterface $logger, array $visitors)
     {
         $this->twig = $twig;
         $this->visitors = $visitors;
@@ -203,7 +207,7 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
         }
 
         $curTwigLoader = $this->twig->getLoader();
-        $this->twig->setLoader(new \Twig_Loader_Array(array()));
+        $this->twig->setLoader(new ArrayLoader(array()));
 
         try {
             $catalogue = new MessageCatalogue();
@@ -227,7 +231,7 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
                         $visitingArgs[] = $ast;
                     } elseif ('twig' === $extension) {
                         $visitingMethod = 'visitTwigFile';
-                        $visitingArgs[] = $this->twig->parse($this->twig->tokenize(new \Twig_Source(file_get_contents($file), (string) $file)));
+                        $visitingArgs[] = $this->twig->parse($this->twig->tokenize(new Source(file_get_contents($file), (string) $file)));
                     }
                 }
 

--- a/Translation/Extractor/FileVisitorInterface.php
+++ b/Translation/Extractor/FileVisitorInterface.php
@@ -19,6 +19,7 @@
 namespace JMS\TranslationBundle\Translation\Extractor;
 
 use JMS\TranslationBundle\Model\MessageCatalogue;
+use Twig\Node\Node;
 
 /**
  * File Visitor Interface.
@@ -55,7 +56,7 @@ interface FileVisitorInterface
      *
      * @param \SplFileInfo $file
      * @param MessageCatalogue $catalogue
-     * @param \Twig_Node $ast
+     * @param Node $ast
      */
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast);
+    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, Node $ast);
 }

--- a/Twig/Node/Transchoice.php
+++ b/Twig/Node/Transchoice.php
@@ -18,14 +18,18 @@
 
 namespace JMS\TranslationBundle\Twig\Node;
 
-class Transchoice extends \Twig_Node_Expression
+use Twig\Compiler;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Expression\ArrayExpression;
+
+class Transchoice extends AbstractExpression
 {
-    public function __construct(\Twig_Node_Expression_Array $arguments, $lineno)
+    public function __construct(ArrayExpression $arguments, $lineno)
     {
         parent::__construct(array('arguments' => $arguments), array(), $lineno);
     }
 
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         $compiler->raw(
             sprintf(

--- a/Twig/NormalizingNodeVisitor.php
+++ b/Twig/NormalizingNodeVisitor.php
@@ -18,6 +18,12 @@
 
 namespace JMS\TranslationBundle\Twig;
 
+use Twig\Environment;
+use Twig\NodeVisitor\AbstractNodeVisitor;
+use Twig\Node\Expression\Binary\ConcatBinary;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Node;
+
 /**
  * Performs equivalence transformations on the AST to ensure that
  * subsequent visitors do not need to be aware of different syntaxes.
@@ -26,29 +32,25 @@ namespace JMS\TranslationBundle\Twig;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class NormalizingNodeVisitor extends \Twig_BaseNodeVisitor
+class NormalizingNodeVisitor extends AbstractNodeVisitor
 {
     /**
-     * @param \Twig_Node $node
-     * @param \Twig_Environment $env
-     * @return \Twig_Node
+     * @return Node
      */
-    protected function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doEnterNode(Node $node, Environment $env)
     {
         return $node;
     }
 
     /**
-     * @param \Twig_Node $node
-     * @param \Twig_Environment $env
-     * @return \Twig_Node_Expression_Constant|\Twig_Node
+     * @return ConstantExpression|Node
      */
-    protected function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doLeaveNode(Node $node, Environment $env)
     {
-        if ($node instanceof \Twig_Node_Expression_Binary_Concat
-            && ($left = $node->getNode('left')) instanceof \Twig_Node_Expression_Constant
-            && ($right = $node->getNode('right')) instanceof \Twig_Node_Expression_Constant) {
-            return new \Twig_Node_Expression_Constant($left->getAttribute('value').$right->getAttribute('value'), $left->getTemplateLine());
+        if ($node instanceof ConcatBinary
+            && ($left = $node->getNode('left')) instanceof ConstantExpression
+            && ($right = $node->getNode('right')) instanceof ConstantExpression) {
+            return new ConstantExpression($left->getAttribute('value').$right->getAttribute('value'), $left->getTemplateLine());
         }
 
         return $node;

--- a/Twig/RemovingNodeVisitor.php
+++ b/Twig/RemovingNodeVisitor.php
@@ -18,12 +18,17 @@
 
 namespace JMS\TranslationBundle\Twig;
 
+use Twig\Environment;
+use Twig\NodeVisitor\AbstractNodeVisitor;
+use Twig\Node\Expression\FilterExpression;
+use Twig\Node\Node;
+
 /**
  * Removes translation metadata filters from the AST.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class RemovingNodeVisitor extends \Twig_BaseNodeVisitor
+class RemovingNodeVisitor extends AbstractNodeVisitor
 {
     /**
      * @var bool
@@ -39,13 +44,11 @@ class RemovingNodeVisitor extends \Twig_BaseNodeVisitor
     }
 
     /**
-     * @param \Twig_Node $node
-     * @param \Twig_Environment $env
-     * @return \Twig_Node
+     * @return Node
      */
-    protected function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doEnterNode(Node $node, Environment $env)
     {
-        if ($this->enabled && $node instanceof \Twig_Node_Expression_Filter) {
+        if ($this->enabled && $node instanceof FilterExpression) {
             $name = $node->getNode('filter')->getAttribute('value');
 
             if ('desc' === $name || 'meaning' === $name) {
@@ -57,11 +60,9 @@ class RemovingNodeVisitor extends \Twig_BaseNodeVisitor
     }
 
     /**
-     * @param \Twig_Node $node
-     * @param \Twig_Environment $env
-     * @return \Twig_Node
+     * @return Node
      */
-    protected function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
+    protected function doLeaveNode(Node $node, Environment $env)
     {
         return $node;
     }

--- a/Twig/TranslationExtension.php
+++ b/Twig/TranslationExtension.php
@@ -24,8 +24,10 @@ namespace JMS\TranslationBundle\Twig;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-class TranslationExtension extends \Twig_Extension
+class TranslationExtension extends AbstractExtension
 {
     /**
      * @var TranslatorInterface
@@ -71,8 +73,8 @@ class TranslationExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('desc', array($this, 'desc')),
-            new \Twig_SimpleFilter('meaning', array($this, 'meaning')),
+            new TwigFilter('desc', array($this, 'desc')),
+            new TwigFilter('meaning', array($this, 'meaning')),
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^5.3.3 || ^7.0",
-        "twig/twig": "^1.27 || ^2.0",
+        "twig/twig": "^1.38 || ^2.7",
         "symfony/framework-bundle": "^2.3 || ^3.0 || ^4.0",
         "nikic/php-parser": "^1.4 || ^2.0 || ^3.0 || ^4.0",
         "symfony/console": "^2.3 || ^3.0 || ^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes, if you consider deprecation notices as bugs
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not less than before
| Fixed tickets | 
| License       | Apache2


## Description
Twig has switched to PSR-4 namespaces, and PSR-0 is dropped in Twig 3.

Refs #516
