### PR TITLE
Replace kernel.root_dir with kernel.project_dir

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -65,7 +65,8 @@
         <service id="jms_translation.config_factory" class="%jms_translation.config_factory.class%" public="true"/>
 
         <service id="jms_translation.file_source_factory" class="%jms_translation.file_source_factory.class%">
-            <argument>%kernel.root_dir%</argument>
+            <argument type="expression">container.hasParameter('kernel.root_dir') ? parameter('kernel.root_dir') : parameter('kernel.project_dir')</argument>
+            <argument>%kernel.project_dir%</argument>
         </service>
 
         <service id="jms_translation.file_writer" class="%jms_translation.file_writer.class%" public="false" />

--- a/Resources/doc/cookbook/config_reference.rst
+++ b/Resources/doc/cookbook/config_reference.rst
@@ -14,10 +14,10 @@ On this page you will find all available configuration options and their meaning
             # Create a configuration named "app"
             app:
                 # List of directories we should extract translations keys from
-                dirs: ["%kernel.root_dir%", "%kernel.root_dir%/../src"]
+                dirs: ["%kernel.project_dir%/src", "%kernel.project_dir%/templates"]
 
                 # Where to write the translation files
-                output_dir: "%kernel.root_dir%/Resources/translations"
+                output_dir: "%kernel.project_dir%/translations"
 
                 # Whitelist domains
                 domains: ["messages"]

--- a/Resources/doc/cookbook/extraction_configs.rst
+++ b/Resources/doc/cookbook/extraction_configs.rst
@@ -10,8 +10,8 @@ also set-up some pre-defined settings via the configuration:
     jms_translation:
         configs:
             app:
-                dirs: ["%kernel.root_dir%", "%kernel.root_dir%/../src"]
-                output_dir: "%kernel.root_dir%/Resources/translations"
+                dirs: ["%kernel.project_dir%/templates", "%kernel.project_dir%/src"]
+                output_dir: "%kernel.project_dir%/translations"
                 ignored_domains: [routes]
                 excluded_names: ["*TestCase.php", "*Test.php"]
                 excluded_dirs: [cache, data, logs]
@@ -26,7 +26,7 @@ You can then run the extraction process with this configuration with the followi
 .. code-block :: bash
 
     php app/console translation:extract de --config=app
-    
+
 The ``--config`` option also supports overriding via command-line options. Let's assume that
 you would like to change the output format that has been defined in the config, but leave all
 other settings the same, you would run:

--- a/Tests/Functional/AppKernel.php
+++ b/Tests/Functional/AppKernel.php
@@ -59,7 +59,22 @@ class AppKernel extends Kernel
         $loader->load($this->config);
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
+    {
+        return $this->getBaseDir().'/cache';
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->getBaseDir().'/logs';
+    }
+
+    public function getProjectDir()
+    {
+        return __DIR__;
+    }
+
+    private function getBaseDir(): string
     {
         return sys_get_temp_dir().'/JMSTranslationBundle';
     }

--- a/Tests/Functional/Command/ResourcesListCommandTest.php
+++ b/Tests/Functional/Command/ResourcesListCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\TranslationBundle\Tests\Functional\Command;
+
+use Symfony\Component\Console\Input\ArgvInput;
+
+final class ResourcesListCommandTest extends BaseCommandTestCase
+{
+    public function testList(): void
+    {
+        $input = new ArgvInput(array(
+            'app/console',
+            'translation:list-resources',
+        ));
+
+        $expectedOutput =
+            'Directories list :'."\n"
+           .'    - %kernel.root_dir%/Fixture/TestBundle/Resources/translations'."\n"
+           .'done!'."\n"
+        ;
+
+        $this->getApp()->run($input, $output = new Output());
+        $this->assertEquals($expectedOutput, $output->getContent());
+    }
+
+    public function testListFiles(): void
+    {
+        $input = new ArgvInput(array(
+            'app/console',
+            'translation:list-resources',
+            '--files'
+        ));
+
+        $expectedOutput =
+            'Resources list :'."\n"
+            .'    - %kernel.project_dir%/Fixture/TestBundle/Resources/translations/messages.en.php'."\n"
+            .'done!'."\n"
+        ;
+
+        $this->getApp()->run($input, $output = new Output());
+        $this->assertEquals($expectedOutput, $output->getContent());
+    }
+}

--- a/Tests/Functional/Controller/ApiControllerTest.php
+++ b/Tests/Functional/Controller/ApiControllerTest.php
@@ -23,9 +23,6 @@ class ApiControllerTest extends BaseTestCase
         // Start application
         $client = static::createClient();
         $client->request('POST', '/_trans/api/configs/app/domains/navigation/locales/en/messages?id=main.home', array('_method'=>'PUT', 'message'=>'Away'));
-if($client->getResponse()->getStatusCode() !== 200) {
-  file_put_contents('/tmp/test-update.html',$client->getResponse());
-}
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
 
         // Verify that the file has new content

--- a/Tests/Functional/Controller/TranslateControllerTest.php
+++ b/Tests/Functional/Controller/TranslateControllerTest.php
@@ -13,10 +13,6 @@ class TranslateControllerTest extends BaseTestCase
     {
         $client = static::createClient();
         $crawler = $client->request('GET', '/_trans/');
-if($client->getResponse()->getStatusCode() !== 200) {
-file_put_contents('/tmp/test-index.html',$client->getResponse());
-}
-
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(
             0,

--- a/Tests/Functional/config/bundle.yml
+++ b/Tests/Functional/config/bundle.yml
@@ -2,9 +2,9 @@ jms_translation:
     configs:
         app:
             dirs:
-                - "%kernel.root_dir%"
-                - "%kernel.root_dir%/Fixture/TestBundle"
-            output_dir: "%kernel.root_dir%/Fixture/TestBundle/Resources/translations"
+                - "%kernel.project_dir%"
+                - "%kernel.project_dir%/Fixture/TestBundle"
+            output_dir: "%kernel.project_dir%/Fixture/TestBundle/Resources/translations"
             ignored_domains: [routes]
             excluded_names: ["*TestCase.php", "*Test.php"]
             excluded_dirs: [cache, data, logs]

--- a/Tests/Functional/config/framework.yml
+++ b/Tests/Functional/config/framework.yml
@@ -5,10 +5,10 @@ framework:
         storage_id: session.storage.mock_file
     form:            true
     csrf_protection: true
-    validation:       
+    validation:
         enabled: true
         enable_annotations: true
     translator:
         enabled: true
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/config/routing.yml"

--- a/Tests/Translation/FileSourceFactoryTest.php
+++ b/Tests/Translation/FileSourceFactoryTest.php
@@ -13,9 +13,9 @@ class FileSourceFactoryTest extends TestCase
      *
      * @dataProvider pathProvider
      */
-    public function testGetRelativePath($root, $file, $expected, $message = '')
+    public function testGetRelativePath($root, $projectRoot, $file, $expected, $message = '')
     {
-        $factory = new FileSourceFactory($root);
+        $factory = new FileSourceFactory($root, $projectRoot);
         $result = NSA::invokeMethod($factory, 'getRelativePath', $file);
 
         $this->assertEquals($expected, $result, $message);
@@ -26,18 +26,21 @@ class FileSourceFactoryTest extends TestCase
         return array(
             array(
                 '/user/foo/application/app',
+                null,
                 '/user/foo/application/src/bundle/controller/index.php',
                 '/../src/bundle/controller/index.php',
             ),
 
             array(
                 '/user/foo/application/app/foo/bar',
+                null,
                 '/user/foo/application/src/bundle/controller/index.php',
                 '/../../../src/bundle/controller/index.php',
             ),
 
             array(
                 '/user/foo/application/app',
+                null,
                 '/user/foo/application/app/../src/AppBundle/Controller/DefaultController.php',
                 '/../src/AppBundle/Controller/DefaultController.php',
                 'Test with "/../" in the file path',
@@ -45,10 +48,42 @@ class FileSourceFactoryTest extends TestCase
 
             array(
                 '/user/foo/application/app/foo/bar/baz/biz/foo',
+                null,
                 '/user/foo/application/src/bundle/controller/index.php',
                 '/../../../../../../src/bundle/controller/index.php',
                 'Test when the root path is longer that file path',
             ),
+
+            array(
+                '/user/foo/application/app',
+                '/user/foo/application',
+                '/user/foo/application/src/bundle/controller/index.php',
+                '/src/bundle/controller/index.php',
+            ),
+
+            array(
+                '/user/foo/application/app/foo/bar',
+                '/user/foo/application/src/foo/bar',
+                '/user/foo/application/src/bundle/controller/index.php',
+                '/../../bundle/controller/index.php',
+            ),
+
+            array(
+                '/user/foo/application/app',
+                '/user/foo/application',
+                '/user/foo/application/app/../src/AppBundle/Controller/DefaultController.php',
+                '/app/../src/AppBundle/Controller/DefaultController.php',
+                'Test with "/../" in the file path',
+            ),
+
+            array(
+                '/user/foo/application/app/foo/bar/baz/biz/foo',
+                '/user/foo/application/src/foo/bar/baz/biz/foo',
+                '/user/foo/application/src/bundle/controller/index.php',
+                '/../../../../../bundle/controller/index.php',
+                'Test when the root path is longer that file path',
+            ),
+
         );
     }
 }

--- a/Translation/FileSourceFactory.php
+++ b/Translation/FileSourceFactory.php
@@ -24,17 +24,25 @@ class FileSourceFactory
 {
     /**
      * @var string
+     *
+     * @deprecated Will be removed in 2.0. Use $baseDir instead.
      */
     protected $kernelRoot;
+
+    /**
+     * @var string
+     */
+    protected $baseDir;
 
     /**
      * FileSourceFactory constructor.
      *
      * @param string $kernelRoot
      */
-    public function __construct($kernelRoot)
+    public function __construct($kernelRoot, string $baseDir = null)
     {
         $this->kernelRoot = $kernelRoot;
+        $this->baseDir = $baseDir ?? $kernelRoot;
     }
 
     /**
@@ -58,15 +66,15 @@ class FileSourceFactory
      */
     private function getRelativePath($path)
     {
-        if (0 === strpos($path, $this->kernelRoot)) {
-            return substr($path, strlen($this->kernelRoot));
+        if (0 === strpos($path, $this->baseDir)) {
+            return substr($path, strlen($this->baseDir));
         }
 
         $relativePath = $ds = DIRECTORY_SEPARATOR;
-        $rootArray = explode($ds, $this->kernelRoot);
+        $rootArray = explode($ds, $this->baseDir);
         $pathArray = explode($ds, $path);
 
-        // Take the first directory in the kernelRoot tree
+        // Take the first directory in the baseDir tree
         foreach ($rootArray as $rootCurrentDirectory) {
             // Take the first directory from the path tree
             $pathCurrentDirectory = array_shift($pathArray);

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/console": "^3.4 || ^4.3",
         "symfony/framework-bundle": "^3.4.31 || ^4.3",
         "symfony/validator": "^3.4 || ^4.3",
-        "twig/twig": "^1.42.3 || ^2.12"
+        "twig/twig": "^1.42.4 || ^2.12.5"
     },
     "require-dev": {
         "doctrine/annotations": "^1.8",
@@ -43,7 +43,7 @@
         "symfony/security-csrf": "^3.4 || ^4.3",
         "symfony/templating": "^3.4 || ^4.3",
         "symfony/translation": "^3.4 || ^4.3",
-        "symfony/twig-bundle": "^3.4 || ^4.3"
+        "symfony/twig-bundle": "^3.4.37 || ^4.3.11"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | Apache2


## Description
[`kernel.root_dir` was deprecated in Symfony 4.2](https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-the-kernel-name-and-the-root-dir) and is removed in 5.0. This PR tries to replace `kernel.root_dir` by `kernel.project_dir` wherever is possible and do not use `kernel.root_dir` if is not defined. I also changed the docs to reference the `translations` folder at the root directory of the project (which is the recommended place).

After this one (and https://github.com/schmittjoh/JMSTranslationBundle/pull/523), I think the only left to do to be able to use SF5 are commands, I'll take a look then.
