### PR TITLE
Cleanup tests

### DIFF
--- a/Tests/Functional/TranslationTest.php
+++ b/Tests/Functional/TranslationTest.php
@@ -10,7 +10,7 @@ class TranslationTest extends BaseTestCase
         $client->request('GET', '/apples/view');
 	$response = $client->getResponse();
 
-        $this->assertEquals(200, $response->getStatusCode(), substr($response, 0, 2000));
+        $this->assertEquals(200, $response->getStatusCode(), $response->getContent());
         $this->assertEquals("There are 5 apples\n\nThere are 5 apples", $response->getContent());
     }
 }

--- a/Tests/Model/FileSourceTest.php
+++ b/Tests/Model/FileSourceTest.php
@@ -106,7 +106,7 @@ class FileSourceTest extends TestCase
         $source
             ->expects($this->once())
             ->method('equals')
-            ->will($this->returnValue(false))
+            ->willReturn(false)
         ;
         $tests[] = array(
             new FileSource('foo'),

--- a/Tests/Model/MessageCollectionTest.php
+++ b/Tests/Model/MessageCollectionTest.php
@@ -76,16 +76,16 @@ class MessageCollectionTest extends TestCase
     public function testSetDoesNotMerge()
     {
         $m2 = $this->createMock('JMS\TranslationBundle\Model\Message');
-        $m2->expects($this->any())
+        $m2
             ->method('getId')
-            ->will($this->returnValue('foo'));
+            ->willReturn('foo');
 
         $m1 = $this->createMock('JMS\TranslationBundle\Model\Message');
         $m1->expects($this->never())
             ->method('merge');
-        $m1->expects($this->any())
+        $m1
             ->method('getId')
-            ->will($this->returnValue('foo'));
+            ->willReturn('foo');
 
         $col = new MessageCollection();
         $col->set($m1);

--- a/Tests/Model/MessageTest.php
+++ b/Tests/Model/MessageTest.php
@@ -184,7 +184,7 @@ class MessageTest extends TestCase
             ->expects($this->once())
             ->method('equals')
             ->with($s2)
-            ->will($this->returnValue(true))
+            ->willReturn(true)
         ;
 
         $message->addSource($s1);

--- a/Tests/Translation/Dumper/ArrayStructureDumperTest.php
+++ b/Tests/Translation/Dumper/ArrayStructureDumperTest.php
@@ -41,7 +41,7 @@ class ArrayStructureDumperTest extends TestCase
                     'bar.baz' => new Message('foo.bar.baz'),
                 ),
             ))
-            ->will($this->returnValue('foo'))
+            ->willReturn('foo')
         ;
 
         $this->assertEquals('foo', $dumper->dump($catalogue, 'messages'));

--- a/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
@@ -34,7 +34,6 @@ abstract class BasePhpFileExtractorTest extends TestCase
         if (!is_file($file = __DIR__.'/Fixture/'.$file)) {
             throw new RuntimeException(sprintf('The file "%s" does not exist.', $file));
         }
-        $file = new \SplFileInfo($file);
 
         if (null === $extractor) {
             $extractor = $this->getDefaultExtractor();
@@ -51,7 +50,7 @@ abstract class BasePhpFileExtractorTest extends TestCase
         $ast = $parser->parse(file_get_contents($file));
 
         $catalogue = new MessageCatalogue();
-        $extractor->visitPhpFile($file, $catalogue, $ast);
+        $extractor->visitPhpFile(new \SplFileInfo($file), $catalogue, $ast);
 
         return $catalogue;
     }

--- a/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithDefaultDomain.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithDefaultDomain.php
@@ -22,7 +22,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class MyFormType extends AbstractType
+class MyFormTypeWithDefaultDomain extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {

--- a/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithDefaultDomainSetDefault.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithDefaultDomainSetDefault.php
@@ -22,7 +22,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class MyFormType extends AbstractType
+class MyFormTypeWithDefaultDomainSetDefault extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {

--- a/Tests/Translation/Extractor/File/TranslationContainerExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TranslationContainerExtractorTest.php
@@ -51,7 +51,6 @@ class TranslationContainerExtractorTest extends TestCase
         if (!is_file($file = __DIR__.'/Fixture/'.$file)) {
             throw new RuntimeException(sprintf('The file "%s" does not exist.', $file));
         }
-        $file = new \SplFileInfo($file);
 
         if (null === $extractor) {
             $extractor = new TranslationContainerExtractor();
@@ -68,7 +67,7 @@ class TranslationContainerExtractorTest extends TestCase
         $ast = $parser->parse(file_get_contents($file));
 
         $catalogue = new MessageCatalogue();
-        $extractor->visitPhpFile($file, $catalogue, $ast);
+        $extractor->visitPhpFile(new \SplFileInfo($file), $catalogue, $ast);
 
         return $catalogue;
     }

--- a/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
@@ -34,7 +34,6 @@ use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Translation\IdentityTranslator;
-use Symfony\Component\Translation\MessageSelector;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\Source;
@@ -146,7 +145,7 @@ class TwigFileExtractorTest extends TestCase
         }
 
         $env = new Environment(new ArrayLoader(array()));
-        $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
+        $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator()));
         $env->addExtension(new TranslationExtension($translator, true));
         $env->addExtension(new RoutingExtension(new UrlGenerator(new RouteCollection(), new RequestContext())));
         $env->addExtension(new FormExtension());

--- a/Tests/Translation/Extractor/File/ValidationExtractorTest.php
+++ b/Tests/Translation/Extractor/File/ValidationExtractorTest.php
@@ -52,7 +52,6 @@ class ValidationExtractorTest extends TestCase
         if (!is_file($file = __DIR__.'/Fixture/'.$file)) {
             throw new RuntimeException(sprintf('The file "%s" does not exist.', $file));
         }
-        $file = new \SplFileInfo($file);
 
         $metadataFactoryClass = LazyLoadingMetadataFactory::class;
 
@@ -72,7 +71,7 @@ class ValidationExtractorTest extends TestCase
         $ast = $parser->parse(file_get_contents($file));
 
         $catalogue = new MessageCatalogue();
-        $extractor->visitPhpFile($file, $catalogue, $ast);
+        $extractor->visitPhpFile(new \SplFileInfo($file), $catalogue, $ast);
 
         return $catalogue;
     }

--- a/Tests/Translation/Extractor/FileExtractorTest.php
+++ b/Tests/Translation/Extractor/FileExtractorTest.php
@@ -34,7 +34,6 @@ use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\File\TranslationContainerExtractor;
 use JMS\TranslationBundle\Translation\Extractor\File\DefaultPhpFileExtractor;
-use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExtension;
@@ -101,7 +100,7 @@ class FileExtractorTest extends TestCase
     private function extract($directory)
     {
         $twig = new Environment(new ArrayLoader(array()));
-        $twig->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
+        $twig->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator()));
         $twig->addExtension(new TranslationExtension($translator));
         $loader=new FilesystemLoader(realpath(__DIR__."/Fixture/SimpleTest/Resources/views/"));
         $twig->setLoader($loader);

--- a/Tests/Translation/ExtractorManagerTest.php
+++ b/Tests/Translation/ExtractorManagerTest.php
@@ -53,7 +53,7 @@ class ExtractorManagerTest extends TestCase
         $bar
             ->expects($this->once())
             ->method('extract')
-            ->will($this->returnValue($catalogue))
+            ->willReturn($catalogue)
         ;
 
         $manager = $this->getManager(null, array(

--- a/Tests/Translation/FileWriterTest.php
+++ b/Tests/Translation/FileWriterTest.php
@@ -33,9 +33,9 @@ class FileWriterTest extends TestCase
         $dumper
             ->expects($this->once())
             ->method('dump')
-            ->will($this->returnCallback(function ($v) use ($self) {
+            ->willReturnCallback(function ($v) use ($self) {
                 $self->assertEquals(array('foo.bar', 'foo.bar.baz'), array_keys($v->getDomain('messages')->all()));
-            }))
+            })
         ;
 
         $writer = new FileWriter(array(

--- a/Tests/Translation/Loader/SymfonyLoaderAdapterTest.php
+++ b/Tests/Translation/Loader/SymfonyLoaderAdapterTest.php
@@ -33,7 +33,7 @@ class SymfonyLoaderAdapterTest extends TestCase
         $symfonyLoader->expects($this->once())
             ->method('load')
             ->with('foo', 'en', 'messages')
-            ->will($this->returnValue($symfonyCatalogue));
+            ->willReturn($symfonyCatalogue);
 
         $adapter = new SymfonyLoaderAdapter($symfonyLoader);
         $bundleCatalogue = $adapter->load('foo', 'en', 'messages');

--- a/Tests/Twig/BaseTwigTestCase.php
+++ b/Tests/Twig/BaseTwigTestCase.php
@@ -19,7 +19,6 @@
 namespace JMS\TranslationBundle\Tests\Twig;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExtension;
 use JMS\TranslationBundle\Twig\TranslationExtension;
@@ -34,7 +33,7 @@ abstract class BaseTwigTestCase extends TestCase
         $content = file_get_contents(__DIR__.'/Fixture/'.$file);
 
         $env = new Environment(new ArrayLoader(array()));
-        $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator(new MessageSelector())));
+        $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator()));
         $env->addExtension(new TranslationExtension($translator, $debug));
 
         return $env->compile($env->parse($env->tokenize(new Source($content, 'whatever')))->getNode('body'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
Just some small clean up, I'll try to keep PR small so it's easy to review.

I've removed the use of `MessageSelector` because in [`3.4`](https://github.com/symfony/translation/blob/3.4/IdentityTranslator.php#L27) there is no need to pass it, in [`4.2` was deprecated](https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#translation) and in [`5.0` has been removed](https://github.com/symfony/symfony/blob/master/UPGRADE-5.0.md#translation).

I'll may try later to add PHPCS to at least tests.