### PR TITLE
Add Doctrine Coding Standards in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ phpunit.xml
 composer.lock
 vendor/
 .phpunit.result.cache
-
+.phpcs-cache
+phpcs.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
+
 sudo: false
-dist: trusty
 
 cache:
     directories:
@@ -12,8 +12,8 @@ php:
   - 7.4
 
 env:
-    global:
-        - TEST_COMMAND="./vendor/bin/phpunit"
+  global:
+    - TARGET=test
 
 matrix:
     fast_finish: true
@@ -22,6 +22,8 @@ matrix:
         - php: 7.2
           env: COMPOSER_FLAGS="--prefer-lowest"
         - php: 7.2
+          env: TARGET=cs
+        - php: 7.2
           env: SYMFONY_VERSION=^3.4
         - php: 7.3
           env: SYMFONY_VERSION=^3.4
@@ -34,16 +36,11 @@ matrix:
         - php: 7.4
           env: SYMFONY_VERSION=^4.3
 
-before_install:
-    - travis_retry composer self-update
-
 install:
-    - if [[ $SYMFONY_VERSION ]]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
-    - COMPOSER_MEMORY_LIMIT=-1 composer update ${COMPOSER_FLAGS} --prefer-source --no-interaction
+  - if [ -x .travis/install_${TARGET}.sh ]; then .travis/install_${TARGET}.sh; fi;
 
 script:
-    - $TEST_COMMAND
+  - if [ -x .travis/script_${TARGET}.sh ]; then .travis/script_${TARGET}.sh; fi;
 
 after_success:
-    - if [[ "$COVERAGE" = true ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-    - if [[ "$COVERAGE" = true ]]; then php ocular.phar code-coverage:upload --format=php-clover build/coverage.xml; fi
+  - if [ -x .travis/success_${TARGET}.sh ]; then .travis/success_${TARGET}.sh; fi;

--- a/.travis/install_cs.sh
+++ b/.travis/install_cs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+composer self-update
+
+phpenv config-rm xdebug.ini
+
+composer update -n

--- a/.travis/install_test.sh
+++ b/.travis/install_test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+composer self-update
+
+if [[ $SYMFONY_VERSION ]]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
+
+COMPOSER_MEMORY_LIMIT=-1 composer update ${COMPOSER_FLAGS} --prefer-source --no-interaction

--- a/.travis/script_cs.sh
+++ b/.travis/script_cs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -ex
+
+vendor/bin/phpcs

--- a/.travis/script_test.sh
+++ b/.travis/script_test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+vendor/bin/phpunit $PHPUNIT_FLAGS
+phpenv config-rm xdebug.ini || true

--- a/.travis/success_test.sh
+++ b/.travis/success_test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [[ "$COVERAGE" = true ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+if [[ "$COVERAGE" = true ]]; then php ocular.phar code-coverage:upload --format=php-clover build/coverage.xml; fi

--- a/Tests/DependencyInjection/Compiler/MountDumpersPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MountDumpersPassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\DependencyInjection\Compiler;
 
 use JMS\TranslationBundle\DependencyInjection\Compiler\MountDumpersPass;
@@ -27,7 +29,7 @@ class MountDumpersPassTest extends AbstractCompilerPassTestCase
         $this->setDefinition('jms_translation.file_writer', $collectingService);
 
         $collectedService = new Definition();
-        $collectedService->addTag('jms_translation.dumper', array('format' => 'foo'));
+        $collectedService->addTag('jms_translation.dumper', ['format' => 'foo']);
         $this->setDefinition('service0', $collectedService);
 
         $this->compile();
@@ -35,7 +37,7 @@ class MountDumpersPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             'jms_translation.file_writer',
             0,
-            array('foo' => new Reference('service0'))
+            ['foo' => new Reference('service0')]
         );
     }
 }

--- a/Tests/DependencyInjection/Compiler/MountDumpersPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MountDumpersPassTest.php
@@ -21,7 +21,7 @@ class MountDumpersPassTest extends AbstractCompilerPassTestCase
     /**
      * @test
      */
-    public function if_compiler_pass_collects_services_by_argument_these_will_exist()
+    public function ifCompilerPassCollectsServicesByArgumentTheseWillExist()
     {
         $collectingService = new Definition();
         $this->setDefinition('jms_translation.file_writer', $collectingService);

--- a/Tests/DependencyInjection/Compiler/MountExtractorsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MountExtractorsPassTest.php
@@ -21,7 +21,7 @@ class MountExtractorsPassTest extends AbstractCompilerPassTestCase
     /**
      * @test
      */
-    public function if_compiler_pass_collects_services_by_argument_these_will_exist()
+    public function ifCompilerPassCollectsServicesByArgumentTheseWillExist()
     {
         $collectingService = new Definition();
         $this->setDefinition('jms_translation.extractor_manager', $collectingService);

--- a/Tests/DependencyInjection/Compiler/MountExtractorsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MountExtractorsPassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\DependencyInjection\Compiler;
 
 use JMS\TranslationBundle\DependencyInjection\Compiler\MountExtractorsPass;
@@ -27,7 +29,7 @@ class MountExtractorsPassTest extends AbstractCompilerPassTestCase
         $this->setDefinition('jms_translation.extractor_manager', $collectingService);
 
         $collectedService = new Definition();
-        $collectedService->addTag('jms_translation.extractor', array('alias' => 'foo'));
+        $collectedService->addTag('jms_translation.extractor', ['alias' => 'foo']);
         $this->setDefinition('service0', $collectedService);
 
         $this->compile();
@@ -35,7 +37,7 @@ class MountExtractorsPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             'jms_translation.extractor_manager',
             0,
-            array('foo' => new Reference('service0'))
+            ['foo' => new Reference('service0')]
         );
     }
 }

--- a/Tests/DependencyInjection/Compiler/MountFileVisitorsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MountFileVisitorsPassTest.php
@@ -21,7 +21,7 @@ class MountFileVisitorsPassTest extends AbstractCompilerPassTestCase
     /**
      * @test
      */
-    public function if_compiler_pass_collects_services_by_argument_these_will_exist()
+    public function ifCompilerPassCollectsServicesByArgumentTheseWillExist()
     {
         $collectingService = new Definition();
         $this->setDefinition('jms_translation.extractor.file_extractor', $collectingService);

--- a/Tests/DependencyInjection/Compiler/MountFileVisitorsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MountFileVisitorsPassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\DependencyInjection\Compiler;
 
 use JMS\TranslationBundle\DependencyInjection\Compiler\MountFileVisitorsPass;
@@ -35,7 +37,7 @@ class MountFileVisitorsPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             'jms_translation.extractor.file_extractor',
             0,
-            array(new Reference('service0'))
+            [new Reference('service0')]
         );
     }
 }

--- a/Tests/DependencyInjection/Compiler/MountLoadersPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MountLoadersPassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\DependencyInjection\Compiler;
 
 use JMS\TranslationBundle\DependencyInjection\Compiler\MountLoadersPass;
@@ -27,7 +29,7 @@ class MountLoadersPassTest extends AbstractCompilerPassTestCase
         $this->setDefinition('jms_translation.loader_manager', $collectingService);
 
         $collectedService = new Definition();
-        $collectedService->addTag('jms_translation.loader', array('format' => 'foo'));
+        $collectedService->addTag('jms_translation.loader', ['format' => 'foo']);
         $this->setDefinition('service0', $collectedService);
 
         $this->compile();
@@ -35,7 +37,7 @@ class MountLoadersPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             'jms_translation.loader_manager',
             0,
-            array('foo' => new Reference('service0'))
+            ['foo' => new Reference('service0')]
         );
     }
 }

--- a/Tests/DependencyInjection/Compiler/MountLoadersPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MountLoadersPassTest.php
@@ -21,7 +21,7 @@ class MountLoadersPassTest extends AbstractCompilerPassTestCase
     /**
      * @test
      */
-    public function if_compiler_pass_collects_services_by_argument_these_will_exist()
+    public function ifCompilerPassCollectsServicesByArgumentTheseWillExist()
     {
         $collectingService = new Definition();
         $this->setDefinition('jms_translation.loader_manager', $collectingService);

--- a/Tests/DependencyInjection/JMSTranslationExtensionTest.php
+++ b/Tests/DependencyInjection/JMSTranslationExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\DependencyInjection;
 
 use JMS\TranslationBundle\DependencyInjection\JMSTranslationExtension;
@@ -12,9 +14,9 @@ class JMSTranslationExtensionTest extends AbstractExtensionTestCase
 {
     protected function getContainerExtensions(): array
     {
-        return array(
+        return [
             new JMSTranslationExtension(),
-        );
+        ];
     }
 
     /**
@@ -32,8 +34,8 @@ class JMSTranslationExtensionTest extends AbstractExtensionTestCase
      */
     public function basicParametersAfterLoading()
     {
-        $locales = array('en', 'fr', 'es');
-        $this->load(array('source_language' => 'fr', 'locales' => $locales));
+        $locales = ['en', 'fr', 'es'];
+        $this->load(['source_language' => 'fr', 'locales' => $locales]);
 
         $this->assertContainerBuilderHasParameter('jms_translation.source_language', 'fr');
         $this->assertContainerBuilderHasParameter('jms_translation.locales', $locales);

--- a/Tests/DependencyInjection/JMSTranslationExtensionTest.php
+++ b/Tests/DependencyInjection/JMSTranslationExtensionTest.php
@@ -20,7 +20,7 @@ class JMSTranslationExtensionTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function default_parameters_after_loading()
+    public function defaultParametersAfterLoading()
     {
         $this->load();
 
@@ -30,7 +30,7 @@ class JMSTranslationExtensionTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function basic_parameters_after_loading()
+    public function basicParametersAfterLoading()
     {
         $locales = array('en', 'fr', 'es');
         $this->load(array('source_language' => 'fr', 'locales' => $locales));

--- a/Tests/Functional/AppKernel.php
+++ b/Tests/Functional/AppKernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -19,8 +21,13 @@
 namespace JMS\TranslationBundle\Tests\Functional;
 
 use JMS\TranslationBundle\Exception\RuntimeException;
-use Symfony\Component\Filesystem\Filesystem;
+use JMS\TranslationBundle\JMSTranslationBundle;
+use JMS\TranslationBundle\Tests\Functional\Fixture\TestBundle\TestBundle;
+use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
@@ -32,11 +39,11 @@ class AppKernel extends Kernel
         parent::__construct('test', true);
 
         $fs = new Filesystem();
-        if (!$fs->isAbsolutePath($config)) {
-            $config = __DIR__.'/config/'.$config;
+        if (! $fs->isAbsolutePath($config)) {
+            $config = __DIR__ . '/config/' . $config;
         }
 
-        if (!file_exists($config)) {
+        if (! file_exists($config)) {
             throw new RuntimeException(sprintf('The config file "%s" does not exist.', $config));
         }
 
@@ -45,13 +52,13 @@ class AppKernel extends Kernel
 
     public function registerBundles()
     {
-        return array(
-            new \JMS\TranslationBundle\Tests\Functional\Fixture\TestBundle\TestBundle(),
-            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new \Symfony\Bundle\TwigBundle\TwigBundle(),
-            new \JMS\TranslationBundle\JMSTranslationBundle(),
-            new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
-        );
+        return [
+            new TestBundle(),
+            new FrameworkBundle(),
+            new TwigBundle(),
+            new JMSTranslationBundle(),
+            new SensioFrameworkExtraBundle(),
+        ];
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)
@@ -61,12 +68,12 @@ class AppKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return $this->getBaseDir().'/cache';
+        return $this->getBaseDir() . '/cache';
     }
 
     public function getLogDir(): string
     {
-        return $this->getBaseDir().'/logs';
+        return $this->getBaseDir() . '/logs';
     }
 
     public function getProjectDir()
@@ -76,7 +83,7 @@ class AppKernel extends Kernel
 
     private function getBaseDir(): string
     {
-        return sys_get_temp_dir().'/JMSTranslationBundle';
+        return sys_get_temp_dir() . '/JMSTranslationBundle';
     }
 
     public function serialize()

--- a/Tests/Functional/BaseTestCase.php
+++ b/Tests/Functional/BaseTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -22,10 +24,10 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class BaseTestCase extends WebTestCase
 {
-    protected static function createKernel(array $options = array())
+    protected static function createKernel(array $options = [])
     {
         return new AppKernel(
-            isset($options['config']) ? $options['config'] : 'default.yml'
+            $options['config'] ?? 'default.yml'
         );
     }
 }

--- a/Tests/Functional/Command/BaseCommandTestCase.php
+++ b/Tests/Functional/Command/BaseCommandTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -23,7 +25,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 abstract class BaseCommandTestCase extends BaseTestCase
 {
-    protected function getApp(array $options = array())
+    protected function getApp(array $options = [])
     {
         $kernel = $this->createKernel($options);
         $kernel->boot();

--- a/Tests/Functional/Command/ExtractCommandTest.php
+++ b/Tests/Functional/Command/ExtractCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,39 +20,36 @@
 
 namespace JMS\TranslationBundle\Tests\Functional\Command;
 
-use JMS\TranslationBundle\Command\ExtractTranslationCommand;
 use JMS\TranslationBundle\Util\FileUtils;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Input\ArgvInput;
 
 class ExtractCommandTest extends BaseCommandTestCase
 {
     public function testExtract()
     {
-        $input = new ArgvInput(array(
+        $input = new ArgvInput([
             'app/console',
             'translation:extract',
             'en',
-            '--dir='.($inputDir = __DIR__.'/../../Translation/Extractor/Fixture/SimpleTest'),
-            '--output-dir='.($outputDir = sys_get_temp_dir().'/'.uniqid('extract'))
-        ));
+            '--dir=' . $inputDir = __DIR__ . '/../../Translation/Extractor/Fixture/SimpleTest',
+            '--output-dir=' . ($outputDir = sys_get_temp_dir() . '/' . uniqid('extract')),
+        ]);
 
         $expectedOutput =
-            'Extracting Translations for locale en'."\n"
-           .'Keep old translations: No'."\n"
-           .'Output-Path: '.$outputDir."\n"
-           .'Directories: '.$inputDir."\n"
-           .'Excluded Directories: Tests'."\n"
-           .'Excluded Names: *Test.php, *TestCase.php'."\n"
-           .'Output-Format: # whatever is present, if nothing then xlf #'."\n"
-           .'Custom Extractors: # none #'."\n"
-           .'============================================================'."\n"
-           .'Loading catalogues from "'.$outputDir.'"'."\n"
-           .'Extracting translation keys'."\n"
-           .'Extracting messages from directory : '.$inputDir."\n"
-           .'Writing translation file "'.$outputDir.'/messages.en.xlf".'."\n"
-           .'done!'."\n"
-        ;
+            'Extracting Translations for locale en' . "\n"
+           . 'Keep old translations: No' . "\n"
+           . 'Output-Path: ' . $outputDir . "\n"
+           . 'Directories: ' . $inputDir . "\n"
+           . 'Excluded Directories: Tests' . "\n"
+           . 'Excluded Names: *Test.php, *TestCase.php' . "\n"
+           . 'Output-Format: # whatever is present, if nothing then xlf #' . "\n"
+           . 'Custom Extractors: # none #' . "\n"
+           . '============================================================' . "\n"
+           . 'Loading catalogues from "' . $outputDir . '"' . "\n"
+           . 'Extracting translation keys' . "\n"
+           . 'Extracting messages from directory : ' . $inputDir . "\n"
+           . 'Writing translation file "' . $outputDir . '/messages.en.xlf".' . "\n"
+           . 'done!' . "\n";
 
         $this->getApp()->run($input, $output = new Output());
         $this->assertEquals($expectedOutput, $output->getContent());
@@ -61,17 +60,17 @@ class ExtractCommandTest extends BaseCommandTestCase
 
     public function testExtractDryRun()
     {
-        $input = new ArgvInput(array(
+        $input = new ArgvInput([
             'app/console',
             'translation:extract',
             'en',
-            '--dir='.($inputDir = __DIR__.'/../../Translation/Extractor/Fixture/SimpleTest'),
-            '--output-dir='.($outputDir = sys_get_temp_dir().'/'.uniqid('extract')),
+            '--dir=' . $inputDir = __DIR__ . '/../../Translation/Extractor/Fixture/SimpleTest',
+            '--output-dir=' . ($outputDir = sys_get_temp_dir() . '/' . uniqid('extract')),
             '--dry-run',
-            '--verbose'
-        ));
+            '--verbose',
+        ]);
 
-        $expectedOutput = array(
+        $expectedOutput = [
             'php.foo->',
             'php.bar-> Bar',
             'php.baz->',
@@ -83,7 +82,7 @@ class ExtractCommandTest extends BaseCommandTestCase
             'form.foo->',
             'form.bar->',
             'controller.foo-> Foo',
-        );
+        ];
 
         $this->getApp()->run($input, $output = new Output());
 

--- a/Tests/Functional/Command/Output.php
+++ b/Tests/Functional/Command/Output.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -28,9 +30,11 @@ class Output extends AbstractOutput
     {
         $this->content .= $content;
 
-        if ($newline) {
-            $this->content .= "\n";
+        if (! $newline) {
+            return;
         }
+
+        $this->content .= "\n";
     }
 
     public function getContent()

--- a/Tests/Functional/Command/ResourcesListCommandTest.php
+++ b/Tests/Functional/Command/ResourcesListCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -24,16 +26,15 @@ final class ResourcesListCommandTest extends BaseCommandTestCase
 {
     public function testList(): void
     {
-        $input = new ArgvInput(array(
+        $input = new ArgvInput([
             'app/console',
             'translation:list-resources',
-        ));
+        ]);
 
         $expectedOutput =
-            'Directories list :'."\n"
-           .'    - %kernel.root_dir%/Fixture/TestBundle/Resources/translations'."\n"
-           .'done!'."\n"
-        ;
+            'Directories list :' . "\n"
+           . '    - %kernel.root_dir%/Fixture/TestBundle/Resources/translations' . "\n"
+           . 'done!' . "\n";
 
         $this->getApp()->run($input, $output = new Output());
         $this->assertEquals($expectedOutput, $output->getContent());
@@ -41,17 +42,16 @@ final class ResourcesListCommandTest extends BaseCommandTestCase
 
     public function testListFiles(): void
     {
-        $input = new ArgvInput(array(
+        $input = new ArgvInput([
             'app/console',
             'translation:list-resources',
-            '--files'
-        ));
+            '--files',
+        ]);
 
         $expectedOutput =
-            'Resources list :'."\n"
-            .'    - %kernel.project_dir%/Fixture/TestBundle/Resources/translations/messages.en.php'."\n"
-            .'done!'."\n"
-        ;
+            'Resources list :' . "\n"
+            . '    - %kernel.project_dir%/Fixture/TestBundle/Resources/translations/messages.en.php' . "\n"
+            . 'done!' . "\n";
 
         $this->getApp()->run($input, $output = new Output());
         $this->assertEquals($expectedOutput, $output->getContent());

--- a/Tests/Functional/Controller/ApiControllerTest.php
+++ b/Tests/Functional/Controller/ApiControllerTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\Functional\Controller;
 
 use JMS\TranslationBundle\Tests\Functional\BaseTestCase;
-use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -14,26 +16,24 @@ class ApiControllerTest extends BaseTestCase
     public function testUpdateAction()
     {
         // Start application
-        $client = static::createClient([
-            'config' => 'test_updating_translations.yml',
-        ]);
+        $client    = static::createClient(['config' => 'test_updating_translations.yml']);
         $outputDir = $client->getContainer()->getParameter('translation_output_dir');
 
-        $isSf4 = version_compare(Kernel::VERSION,'4.0.0') >= 0;
+        $isSf4 = version_compare(Kernel::VERSION, '4.0.0') >= 0;
 
         // Add a file
-        $file = $isSf4 ? $outputDir.'/navigation.en.yaml' : $outputDir.'/navigation.en.yml';
+        $file    = $isSf4 ? $outputDir . '/navigation.en.yaml' : $outputDir . '/navigation.en.yml';
         $written = file_put_contents($file, 'main.home: Home');
         $this->assertTrue($written !== false && $written > 0);
 
-        $client->request('POST', '/_trans/api/configs/app/domains/navigation/locales/en/messages?id=main.home', array('_method'=>'PUT', 'message'=>'Away'));
+        $client->request('POST', '/_trans/api/configs/app/domains/navigation/locales/en/messages?id=main.home', ['_method' => 'PUT', 'message' => 'Away']);
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
 
         // Verify that the file has new content
         $array = Yaml::parse(file_get_contents($file));
 
         if ($isSf4) {
-            $this->assertTrue(isset($array['main.home']),print_r($array,true));
+            $this->assertTrue(isset($array['main.home']), print_r($array, true));
             $this->assertEquals('Away', $array['main.home']);
         } else {
             $this->assertTrue(isset($array['main']));

--- a/Tests/Functional/Controller/TranslateControllerTest.php
+++ b/Tests/Functional/Controller/TranslateControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\Functional\Controller;
 
 use JMS\TranslationBundle\Tests\Functional\BaseTestCase;
@@ -11,7 +13,7 @@ class TranslateControllerTest extends BaseTestCase
 {
     public function testIndexAction()
     {
-        $client = static::createClient();
+        $client  = static::createClient();
         $crawler = $client->request('GET', '/_trans/');
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
         $this->assertGreaterThan(

--- a/Tests/Functional/Fixture/TestBundle/Controller/AppleController.php
+++ b/Tests/Functional/Fixture/TestBundle/Controller/AppleController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\Functional\Fixture\TestBundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -17,6 +19,6 @@ class AppleController
      */
     public function viewAction()
     {
-        return array('nbApples' => 5);
+        return ['nbApples' => 5];
     }
 }

--- a/Tests/Functional/Fixture/TestBundle/TestBundle.php
+++ b/Tests/Functional/Fixture/TestBundle/TestBundle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\Functional\Fixture\TestBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/Tests/Functional/ServiceInstantiationTest.php
+++ b/Tests/Functional/ServiceInstantiationTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\Functional;
 
-use JMS\TranslationBundle\Twig\TranslationExtension;
 use JMS\TranslationBundle\Translation\ConfigFactory;
 use JMS\TranslationBundle\Translation\Updater;
+use JMS\TranslationBundle\Twig\TranslationExtension;
 
 /**
  * Make sure we instantiate services.
@@ -20,11 +22,11 @@ class ServiceInstantiationTest extends BaseTestCase
 
     public function provider()
     {
-        return array(
-            array('jms_translation.updater', Updater::class),
-            array('jms_translation.config_factory', ConfigFactory::class),
-            array('jms_translation.twig_extension', TranslationExtension::class),
-        );
+        return [
+            ['jms_translation.updater', Updater::class],
+            ['jms_translation.config_factory', ConfigFactory::class],
+            ['jms_translation.twig_extension', TranslationExtension::class],
+        ];
     }
 
     /**

--- a/Tests/Functional/TranslationTest.php
+++ b/Tests/Functional/TranslationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\Functional;
 
 class TranslationTest extends BaseTestCase
@@ -8,7 +10,7 @@ class TranslationTest extends BaseTestCase
     {
         $client = $this->createClient();
         $client->request('GET', '/apples/view');
-	$response = $client->getResponse();
+        $response = $client->getResponse();
 
         $this->assertEquals(200, $response->getStatusCode(), $response->getContent());
         $this->assertEquals("There are 5 apples\n\nThere are 5 apples", $response->getContent());

--- a/Tests/Model/FileSourceTest.php
+++ b/Tests/Model/FileSourceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -64,55 +66,54 @@ class FileSourceTest extends TestCase
 
     public function getEqualityTests()
     {
-        $tests = array();
+        $tests = [];
 
-        $tests[] = array(
+        $tests[] = [
             new FileSource('foo'),
             new FileSource('foo'),
             true,
-        );
+        ];
 
-        $tests[] = array(
+        $tests[] = [
             new FileSource('foo'),
             new FileSource('bar'),
             false,
-        );
+        ];
 
-        $tests[] = array(
+        $tests[] = [
             new FileSource('foo', 1),
             new FileSource('foo', 1),
             true,
-        );
+        ];
 
-        $tests[] = array(
+        $tests[] = [
             new FileSource('foo', 1),
             new FileSource('foo', 2),
             false,
-        );
+        ];
 
-        $tests[] = array(
+        $tests[] = [
             new FileSource('foo', 1, 2),
             new FileSource('foo', 1, 2),
             true,
-        );
+        ];
 
-        $tests[] = array(
+        $tests[] = [
             new FileSource('foo', 1, 2),
             new FileSource('foo', 1, 3),
             false,
-        );
+        ];
 
         $source = $this->createMock('JMS\TranslationBundle\Model\SourceInterface');
         $source
             ->expects($this->once())
             ->method('equals')
-            ->willReturn(false)
-        ;
-        $tests[] = array(
+            ->willReturn(false);
+        $tests[] = [
             new FileSource('foo'),
             $source,
             false,
-        );
+        ];
 
         return $tests;
     }
@@ -127,13 +128,13 @@ class FileSourceTest extends TestCase
 
     public function getToStringTests()
     {
-        $tests = array();
+        $tests = [];
 
-        $tests[] = array(new FileSource('foo/bar'), 'foo/bar');
-        $tests[] = array(new FileSource('foo/bar', 1), 'foo/bar on line 1');
-        $tests[] = array(new FileSource('foo/bar', null, 2), 'foo/bar');
-        $tests[] = array(new FileSource('foo/bar', 1, 2), 'foo/bar on line 1 at column 2');
-        $tests[] = array(new FileSource('a/b/c/foo/bar'), 'a/b/c/foo/bar');
+        $tests[] = [new FileSource('foo/bar'), 'foo/bar'];
+        $tests[] = [new FileSource('foo/bar', 1), 'foo/bar on line 1'];
+        $tests[] = [new FileSource('foo/bar', null, 2), 'foo/bar'];
+        $tests[] = [new FileSource('foo/bar', 1, 2), 'foo/bar on line 1 at column 2'];
+        $tests[] = [new FileSource('a/b/c/foo/bar'), 'a/b/c/foo/bar'];
 
         return $tests;
     }

--- a/Tests/Model/Message/XliffMessageTest.php
+++ b/Tests/Model/Message/XliffMessageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2013 Dieter Peeters <schmittjoh@gmail.com>
  *
@@ -92,12 +94,12 @@ class XliffMessageTest extends MessageTest
     public function testGetNotes()
     {
         $message = new XliffMessage('foo');
-        $this->assertEquals(array(), $message->getNotes());
+        $this->assertEquals([], $message->getNotes());
         $this->assertSame($message, $message->addNote('foo'));
-        $this->assertSame(array(array('text' => 'foo')), $message->getNotes());
+        $this->assertSame([['text' => 'foo']], $message->getNotes());
         $this->assertSame($message, $message->addNote('bar', 'foo'));
-        $this->assertSame(array(array('text' => 'foo'), array('text' => 'bar', 'from' => 'foo')), $message->getNotes());
-        $this->assertSame($message, $message->setNotes($notes = array(array('text' => 'foo', 'from' => 'bar'))));
+        $this->assertSame([['text' => 'foo'], ['text' => 'bar', 'from' => 'foo']], $message->getNotes());
+        $this->assertSame($message, $message->setNotes($notes = [['text' => 'foo', 'from' => 'bar']]));
         $this->assertSame($notes, $message->getNotes());
     }
 
@@ -123,7 +125,7 @@ class XliffMessageTest extends MessageTest
         $message1->merge($message2);
         $this->assertEquals('bar', $message1->getDesc());
         $this->assertEquals('foo', $message1->getMeaning());
-        $this->assertSame(array($s1, $s2), $message1->getSources());
+        $this->assertSame([$s1, $s2], $message1->getSources());
         $this->assertTrue($message1->isApproved());
         $this->assertEquals(XliffMessage::STATE_TRANSLATED, $message1->getState());
 
@@ -143,7 +145,7 @@ class XliffMessageTest extends MessageTest
         $message5->merge($message6);
         $this->assertEquals('bar', $message5->getDesc());
         $this->assertEquals('foo', $message5->getMeaning());
-        $this->assertSame(array($s1, $s2), $message5->getSources());
+        $this->assertSame([$s1, $s2], $message5->getSources());
         $this->assertFalse($message5->isApproved());
         $this->assertEquals(XliffMessage::STATE_NEW, $message5->getState());
 
@@ -173,13 +175,13 @@ class XliffMessageTest extends MessageTest
         $existingMessage2->setNew(false);
         $existingMessage2->addSource(new FileSource('bar'));
 
-        $scannedMessage1 = clone $scannedMessage;
+        $scannedMessage1  = clone $scannedMessage;
         $existingMessage1 = clone $existingMessage;
         $scannedMessage1->mergeExisting($existingMessage1);
         $this->assertEquals('foo', $scannedMessage1->getDesc());
         $this->assertEquals('bar', $scannedMessage1->getLocaleString());
         $this->assertFalse($scannedMessage1->isNew());
-        $this->assertEquals(array(), $scannedMessage1->getSources());
+        $this->assertEquals([], $scannedMessage1->getSources());
         $this->assertFalse($scannedMessage1->isApproved());
         $this->assertEquals(XliffMessage::STATE_NONE, $scannedMessage1->getState());
 
@@ -195,13 +197,13 @@ class XliffMessageTest extends MessageTest
         $this->assertTrue($scannedMessage2->isApproved());
         $this->assertEquals(XliffMessage::STATE_TRANSLATED, $scannedMessage2->getState());
 
-        $scannedMessage3 = clone $scannedMessage;
+        $scannedMessage3  = clone $scannedMessage;
         $existingMessage3 = clone $existingMessage1;
         $scannedMessage3->mergeExisting($existingMessage3);
         $this->assertEquals('foo', $scannedMessage3->getDesc());
         $this->assertEquals('bar', $scannedMessage3->getLocaleString());
         $this->assertFalse($scannedMessage3->isNew());
-        $this->assertEquals(array(), $scannedMessage3->getSources());
+        $this->assertEquals([], $scannedMessage3->getSources());
         $this->assertFalse($scannedMessage3->isApproved());
         $this->assertEquals(XliffMessage::STATE_NONE, $scannedMessage3->getState());
 
@@ -233,12 +235,12 @@ class XliffMessageTest extends MessageTest
         $scannedMessage1->setDesc('foo');
 
         $existingMessage1 = clone $existingMessage;
-        $scannedMessage1 = clone $scannedMessage;
+        $scannedMessage1  = clone $scannedMessage;
         $existingMessage1->mergeScanned($scannedMessage1);
         $this->assertEquals('foo', $existingMessage1->getDesc());
         $this->assertEquals('bar', $existingMessage1->getLocaleString());
         $this->assertFalse($existingMessage1->isNew());
-        $this->assertEquals(array(), $existingMessage1->getSources());
+        $this->assertEquals([], $existingMessage1->getSources());
         $this->assertTrue($existingMessage1->isApproved());
         $this->assertEquals(XliffMessage::STATE_TRANSLATED, $existingMessage1->getState());
 
@@ -253,17 +255,17 @@ class XliffMessageTest extends MessageTest
         $existingMessage2->mergeScanned($scannedMessage2);
         $this->assertEquals('bar', $existingMessage2->getDesc());
         $this->assertFalse($existingMessage2->isNew());
-        $this->assertEquals(array(), $existingMessage2->getSources());
+        $this->assertEquals([], $existingMessage2->getSources());
         $this->assertTrue($existingMessage2->isApproved());
         $this->assertEquals(XliffMessage::STATE_TRANSLATED, $existingMessage2->getState());
 
         $existingMessage3 = clone $existingMessage;
-        $scannedMessage3 = clone $scannedMessage1;
+        $scannedMessage3  = clone $scannedMessage1;
         $existingMessage3->mergeScanned($scannedMessage3);
         $this->assertEquals('foo', $existingMessage3->getDesc());
         $this->assertEquals('bar', $existingMessage3->getLocaleString());
         $this->assertFalse($existingMessage3->isNew());
-        $this->assertEquals(array(), $existingMessage3->getSources());
+        $this->assertEquals([], $existingMessage3->getSources());
         $this->assertTrue($existingMessage3->isApproved());
         $this->assertEquals(XliffMessage::STATE_TRANSLATED, $existingMessage3->getState());
 
@@ -275,7 +277,7 @@ class XliffMessageTest extends MessageTest
         $scannedMessage4->setDesc('foo');
         $existingMessage4->mergeScanned($scannedMessage4);
         $this->assertEquals('bar', $existingMessage4->getDesc());
-        $this->assertEquals(array(), $existingMessage4->getSources());
+        $this->assertEquals([], $existingMessage4->getSources());
         $this->assertTrue($existingMessage4->isApproved());
         $this->assertEquals(XliffMessage::STATE_TRANSLATED, $existingMessage4->getState());
     }

--- a/Tests/Model/MessageCatalogueTest.php
+++ b/Tests/Model/MessageCatalogueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -30,7 +32,7 @@ class MessageCatalogueTest extends TestCase
         $catalogue->add($m = new Message('foo'));
 
         $this->assertTrue($catalogue->hasDomain('messages'));
-        $this->assertEquals(array('foo' => $m), $catalogue->getDomain('messages')->all());
+        $this->assertEquals(['foo' => $m], $catalogue->getDomain('messages')->all());
     }
 
     public function testGet()
@@ -75,7 +77,7 @@ class MessageCatalogueTest extends TestCase
 
         $col = $catalogue->getDomain('messages');
         $this->assertInstanceOf('JMS\TranslationBundle\Model\MessageCollection', $col);
-        $this->assertEquals(array('foo'), array_keys($col->all()));
+        $this->assertEquals(['foo'], array_keys($col->all()));
     }
 
     public function testGetDomainWhenDomainDoesNotExist()
@@ -92,7 +94,7 @@ class MessageCatalogueTest extends TestCase
         $cat->add(new Message('foo'));
         $cat->add(new Message('foo', 'foo'));
 
-        $this->assertEquals(array('messages', 'foo'), array_keys($domains = $cat->getDomains()));
+        $this->assertEquals(['messages', 'foo'], array_keys($domains = $cat->getDomains()));
         $this->assertInstanceOf('JMS\TranslationBundle\Model\MessageCollection', $domains['foo']);
     }
 
@@ -106,10 +108,10 @@ class MessageCatalogueTest extends TestCase
 
         $cat->merge($cat2);
 
-        $this->assertEquals(array('foo', 'bar'), array_keys($domains = $cat->getDomains()));
-        $this->assertEquals(array('bar'), array_keys($cat2->getDomains()));
+        $this->assertEquals(['foo', 'bar'], array_keys($domains = $cat->getDomains()));
+        $this->assertEquals(['bar'], array_keys($cat2->getDomains()));
 
-        $this->assertEquals(array('foo'), array_keys($domains['foo']->all()));
-        $this->assertEquals(array('foo'), array_keys($domains['bar']->all()));
+        $this->assertEquals(['foo'], array_keys($domains['foo']->all()));
+        $this->assertEquals(['foo'], array_keys($domains['bar']->all()));
     }
 }

--- a/Tests/Model/MessageCollectionTest.php
+++ b/Tests/Model/MessageCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,9 +20,9 @@
 
 namespace JMS\TranslationBundle\Tests\Model;
 
+use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCollection;
-use JMS\TranslationBundle\Model\FileSource;
 use PHPUnit\Framework\TestCase;
 
 class MessageCollectionTest extends TestCase
@@ -30,7 +32,7 @@ class MessageCollectionTest extends TestCase
         $domain = new MessageCollection();
         $domain->add($m = new Message('foo'));
 
-        $this->assertSame(array('foo' => $m), $domain->all());
+        $this->assertSame(['foo' => $m], $domain->all());
     }
 
     public function testAddMerges()
@@ -101,10 +103,10 @@ class MessageCollectionTest extends TestCase
         $col->add(new Message('c'));
         $col->add(new Message('a'));
 
-        $this->assertEquals(array('b', 'c', 'a'), array_keys($col->all()));
+        $this->assertEquals(['b', 'c', 'a'], array_keys($col->all()));
 
         $col->sort('strcasecmp');
-        $this->assertEquals(array('a', 'b', 'c'), array_keys($col->all()));
+        $this->assertEquals(['a', 'b', 'c'], array_keys($col->all()));
     }
 
     public function testFilter()
@@ -113,9 +115,11 @@ class MessageCollectionTest extends TestCase
         $col->add($m = new Message('a'));
         $col->add(new Message('b'));
         $col->add(new Message('c'));
-        $col->filter(function ($v) { return 'a' === $v->getId(); });
+        $col->filter(static function ($v) {
+            return $v->getId() === 'a';
+        });
 
-        $this->assertEquals(array('a'), array_keys($col->all()));
+        $this->assertEquals(['a'], array_keys($col->all()));
         $this->assertSame($m, $col->get('a'));
     }
 
@@ -128,7 +132,7 @@ class MessageCollectionTest extends TestCase
         $col2->add(new Message('b'));
 
         $col->merge($col2);
-        $this->assertEquals(array('a', 'b'), array_keys($col->all()));
+        $this->assertEquals(['a', 'b'], array_keys($col->all()));
     }
 
     public function testAddChecksConsistency()
@@ -159,7 +163,7 @@ class MessageCollectionTest extends TestCase
 
         // both message have not desc
 
-        $msg = new Message('a');
+        $msg  = new Message('a');
         $msg2 = new Message('a');
 
         $col->add($msg);
@@ -225,7 +229,7 @@ class MessageCollectionTest extends TestCase
 
         // both message have not desc
 
-        $msg = new Message('a');
+        $msg  = new Message('a');
         $msg2 = new Message('a');
 
         $col->set($msg);

--- a/Tests/Model/MessageTest.php
+++ b/Tests/Model/MessageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -78,12 +80,12 @@ class MessageTest extends TestCase
     public function testGetSources()
     {
         $message = new Message('foo');
-        $this->assertEquals(array(), $message->getSources());
+        $this->assertEquals([], $message->getSources());
 
         $this->assertSame($message, $message->addSource($source = $this->createMock('JMS\TranslationBundle\Model\SourceInterface')));
-        $this->assertSame(array($source), $message->getSources());
-        $this->assertSame($message, $message->setSources(array($source2 = $this->createMock('JMS\TranslationBundle\Model\SourceInterface'))));
-        $this->assertSame(array($source2), $message->getSources());
+        $this->assertSame([$source], $message->getSources());
+        $this->assertSame($message, $message->setSources([$source2 = $this->createMock('JMS\TranslationBundle\Model\SourceInterface')]));
+        $this->assertSame([$source2], $message->getSources());
     }
 
     public function testMerge()
@@ -101,7 +103,7 @@ class MessageTest extends TestCase
 
         $this->assertEquals('bar', $message->getDesc());
         $this->assertEquals('foo', $message->getMeaning());
-        $this->assertSame(array($s1, $s2), $message->getSources());
+        $this->assertSame([$s1, $s2], $message->getSources());
     }
 
     public function testMergeRememberDesc()
@@ -119,7 +121,7 @@ class MessageTest extends TestCase
 
         $this->assertEquals('foo_desc', $message->getDesc());
         $this->assertEquals('bar_meaning', $message->getMeaning());
-        $this->assertSame(array($s1, $s2), $message->getSources());
+        $this->assertSame([$s1, $s2], $message->getSources());
     }
 
     public function testMergeExisting()
@@ -137,7 +139,7 @@ class MessageTest extends TestCase
         $this->assertEquals('bar', $message->getDesc());
         $this->assertEquals('foobar', $message->getLocaleString());
         $this->assertFalse($message->isNew());
-        $this->assertEquals(array(), $message->getSources());
+        $this->assertEquals([], $message->getSources());
     }
 
     public function testMergeScanned()
@@ -155,7 +157,7 @@ class MessageTest extends TestCase
         $this->assertEquals('foobar', $message->getDesc());
         $this->assertEquals('foobar', $message->getLocaleString());
         $this->assertFalse($message->isNew());
-        $this->assertEquals(array(), $message->getSources());
+        $this->assertEquals([], $message->getSources());
     }
 
     public function testGetIsNew()
@@ -184,8 +186,7 @@ class MessageTest extends TestCase
             ->expects($this->once())
             ->method('equals')
             ->with($s2)
-            ->willReturn(true)
-        ;
+            ->willReturn(true);
 
         $message->addSource($s1);
         $this->assertTrue($message->hasSource($s2));

--- a/Tests/Translation/Comparison/CatalogueComparatorTest.php
+++ b/Tests/Translation/Comparison/CatalogueComparatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,10 +20,10 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Comparison;
 
-use JMS\TranslationBundle\Translation\Comparison\CatalogueComparator;
-use JMS\TranslationBundle\Translation\Comparison\ChangeSet;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\Comparison\CatalogueComparator;
+use JMS\TranslationBundle\Translation\Comparison\ChangeSet;
 use PHPUnit\Framework\TestCase;
 
 class CatalogueComparatorTest extends TestCase
@@ -36,9 +38,9 @@ class CatalogueComparatorTest extends TestCase
         $new->add(new Message('foo'));
         $new->add(new Message('bar'));
 
-        $expected = new ChangeSet(
-            array(new Message('bar')),
-            array(Message::create('bar', 'routes')->setLocaleString('baz'))
+        $expected   = new ChangeSet(
+            [new Message('bar')],
+            [Message::create('bar', 'routes')->setLocaleString('baz')]
         );
         $comparator = new CatalogueComparator();
 

--- a/Tests/Translation/Dumper/ArrayStructureDumperTest.php
+++ b/Tests/Translation/Dumper/ArrayStructureDumperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -35,14 +37,13 @@ class ArrayStructureDumperTest extends TestCase
         $dumper
             ->expects($this->once())
             ->method('dumpStructure')
-            ->with(array(
-                'foo' => array(
+            ->with([
+                'foo' => [
                     'bar' => new Message('foo.bar'),
                     'bar.baz' => new Message('foo.bar.baz'),
-                ),
-            ))
-            ->willReturn('foo')
-        ;
+                ],
+            ])
+            ->willReturn('foo');
 
         $this->assertEquals('foo', $dumper->dump($catalogue, 'messages'));
     }

--- a/Tests/Translation/Dumper/BaseDumperTest.php
+++ b/Tests/Translation/Dumper/BaseDumperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,9 +20,9 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Dumper;
 
-use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
 use PHPUnit\Framework\TestCase;
 
 abstract class BaseDumperTest extends TestCase
@@ -82,6 +84,7 @@ abstract class BaseDumperTest extends TestCase
     }
 
     abstract protected function getDumper();
+
     abstract protected function getOutput($key);
 
     private function dump(MessageCatalogue $catalogue, $domain)

--- a/Tests/Translation/Dumper/PhpDumperTest.php
+++ b/Tests/Translation/Dumper/PhpDumperTest.php
@@ -44,10 +44,11 @@ class PhpDumperTest extends BaseDumperTest
 
     protected function getOutput($key)
     {
-        if (!is_file($file = __DIR__.'/php/'.$key.'.php')) {
+        $fileRealPath = __DIR__.'/php/'.$key.'.php';
+        if (!is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('There is no output for key "%s".', $key));
         }
 
-        return file_get_contents($file);
+        return file_get_contents($fileRealPath);
     }
 }

--- a/Tests/Translation/Dumper/PhpDumperTest.php
+++ b/Tests/Translation/Dumper/PhpDumperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -44,8 +46,8 @@ class PhpDumperTest extends BaseDumperTest
 
     protected function getOutput($key)
     {
-        $fileRealPath = __DIR__.'/php/'.$key.'.php';
-        if (!is_file($fileRealPath)) {
+        $fileRealPath = __DIR__ . '/php/' . $key . '.php';
+        if (! is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('There is no output for key "%s".', $key));
         }
 

--- a/Tests/Translation/Dumper/XliffDumperTest.php
+++ b/Tests/Translation/Dumper/XliffDumperTest.php
@@ -149,7 +149,8 @@ EOF;
 
     protected function getOutput($key)
     {
-        if (!is_file($file = __DIR__.'/xliff/'.$key.'.xml')) {
+        $fileRealPath = __DIR__.'/xliff/'.$key.'.xml';
+        if (!is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('There is no output for key "%s".', $key));
         }
 
@@ -157,6 +158,6 @@ EOF;
 //         $doc = \DOMDocument::load($file);
 //         $this->assertTrue($doc->schemaValidate(__DIR__.'/../../../Resources/schema/xliff-core-1.2-strict.xsd'));
 
-        return file_get_contents($file);
+        return file_get_contents($fileRealPath);
     }
 }

--- a/Tests/Translation/Dumper/XliffDumperTest.php
+++ b/Tests/Translation/Dumper/XliffDumperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,10 +20,10 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Dumper;
 
+use JMS\TranslationBundle\Exception\InvalidArgumentException;
 use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
-use JMS\TranslationBundle\Exception\InvalidArgumentException;
 use JMS\TranslationBundle\Translation\Dumper\XliffDumper;
 
 class XliffDumperTest extends BaseDumperTest
@@ -149,8 +151,8 @@ EOF;
 
     protected function getOutput($key)
     {
-        $fileRealPath = __DIR__.'/xliff/'.$key.'.xml';
-        if (!is_file($fileRealPath)) {
+        $fileRealPath = __DIR__ . '/xliff/' . $key . '.xml';
+        if (! is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('There is no output for key "%s".', $key));
         }
 

--- a/Tests/Translation/Dumper/YamlDumperTest.php
+++ b/Tests/Translation/Dumper/YamlDumperTest.php
@@ -44,10 +44,11 @@ class YamlDumperTest extends BaseDumperTest
 
     protected function getOutput($key)
     {
-        if (!is_file($file = __DIR__.'/yml/'.$key.'.yml')) {
+        $fileRealPath = __DIR__.'/yml/'.$key.'.yml';
+        if (!is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('There is no output for key "%s".', $key));
         }
 
-        return file_get_contents($file);
+        return file_get_contents($fileRealPath);
     }
 }

--- a/Tests/Translation/Dumper/YamlDumperTest.php
+++ b/Tests/Translation/Dumper/YamlDumperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -44,8 +46,8 @@ class YamlDumperTest extends BaseDumperTest
 
     protected function getOutput($key)
     {
-        $fileRealPath = __DIR__.'/yml/'.$key.'.yml';
-        if (!is_file($fileRealPath)) {
+        $fileRealPath = __DIR__ . '/yml/' . $key . '.yml';
+        if (! is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('There is no output for key "%s".', $key));
         }
 

--- a/Tests/Translation/Extractor/File/AuthenticationMessagesExtractorTest.php
+++ b/Tests/Translation/Extractor/File/AuthenticationMessagesExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -29,16 +31,16 @@ class AuthenticationMessagesExtractorTest extends BasePhpFileExtractorTest
         $expected = new MessageCatalogue();
 
         $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyAuthException.php');
+        $fixtureSplInfo    = new \SplFileInfo(__DIR__ . '/Fixture/MyAuthException.php');
 
         $message = new Message('security.authentication_error.foo', 'authentication');
         $message->setDesc('%foo% is invalid.');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 31));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 33));
         $expected->add($message);
 
         $message = new Message('security.authentication_error.bar', 'authentication');
         $message->setDesc('An authentication error occurred.');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 35));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 37));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('MyAuthException.php'));

--- a/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
@@ -31,8 +31,9 @@ abstract class BasePhpFileExtractorTest extends TestCase
 {
     final protected function extract($file, FileVisitorInterface $extractor = null)
     {
-        if (!is_file($file = __DIR__.'/Fixture/'.$file)) {
-            throw new RuntimeException(sprintf('The file "%s" does not exist.', $file));
+        $fileRealPath = __DIR__.'/Fixture/'.$file;
+        if (!is_file($fileRealPath)) {
+            throw new RuntimeException(sprintf('The file "%s" does not exist.', $fileRealPath));
         }
 
         if (null === $extractor) {
@@ -47,10 +48,10 @@ abstract class BasePhpFileExtractorTest extends TestCase
             $parser = new Parser($lexer);
         }
 
-        $ast = $parser->parse(file_get_contents($file));
+        $ast = $parser->parse(file_get_contents($fileRealPath));
 
         $catalogue = new MessageCatalogue();
-        $extractor->visitPhpFile(new \SplFileInfo($file), $catalogue, $ast);
+        $extractor->visitPhpFile(new \SplFileInfo($fileRealPath), $catalogue, $ast);
 
         return $catalogue;
     }

--- a/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,8 +20,8 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Extractor\File;
 
-use JMS\TranslationBundle\Model\MessageCatalogue;
 use Doctrine\Common\Annotations\DocParser;
+use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use JMS\TranslationBundle\Translation\FileSourceFactory;
 use PhpParser\Lexer;
@@ -29,21 +31,21 @@ use PHPUnit\Framework\TestCase;
 
 abstract class BasePhpFileExtractorTest extends TestCase
 {
-    final protected function extract($file, FileVisitorInterface $extractor = null)
+    final protected function extract($file, ?FileVisitorInterface $extractor = null)
     {
-        $fileRealPath = __DIR__.'/Fixture/'.$file;
-        if (!is_file($fileRealPath)) {
+        $fileRealPath = __DIR__ . '/Fixture/' . $file;
+        if (! is_file($fileRealPath)) {
             throw new RuntimeException(sprintf('The file "%s" does not exist.', $fileRealPath));
         }
 
-        if (null === $extractor) {
+        if ($extractor === null) {
             $extractor = $this->getDefaultExtractor();
         }
 
         $lexer = new Lexer();
         if (class_exists('PhpParser\ParserFactory')) {
             $factory = new ParserFactory();
-            $parser = $factory->create(ParserFactory::PREFER_PHP7, $lexer);
+            $parser  = $factory->create(ParserFactory::PREFER_PHP7, $lexer);
         } else {
             $parser = new Parser($lexer);
         }
@@ -61,11 +63,11 @@ abstract class BasePhpFileExtractorTest extends TestCase
     final protected function getDocParser()
     {
         $docParser = new DocParser();
-        $docParser->setImports(array(
+        $docParser->setImports([
             'desc' => 'JMS\TranslationBundle\Annotation\Desc',
             'meaning' => 'JMS\TranslationBundle\Annotation\Meaning',
             'ignore' => 'JMS\TranslationBundle\Annotation\Ignore',
-        ));
+        ]);
         $docParser->setIgnoreNotImportedAnnotations(true);
 
         return $docParser;

--- a/Tests/Translation/Extractor/File/DefaultPhpFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/DefaultPhpFileExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -29,37 +31,37 @@ class DefaultPhpFileExtractorTest extends BasePhpFileExtractorTest
         $catalogue = $this->extract('Controller.php');
 
         $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/Controller.php');
+        $fixtureSplInfo    = new \SplFileInfo(__DIR__ . '/Fixture/Controller.php');
 
         $expected = new MessageCatalogue();
 
         $message = new Message('text.foo_bar');
         $message->setDesc('Foo bar');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 45));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 47));
         $expected->add($message);
 
         $message = new Message('text.sign_up_successful');
         $message->setDesc('Welcome %name%! Thanks for signing up.');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 52));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 55));
         $expected->add($message);
 
         $message = new Message('button.archive');
         $message->setDesc('Archive Message');
         $message->setMeaning('The verb (to archive), describes an action');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 59));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 64));
         $expected->add($message);
 
         $message = new Message('text.irrelevant_doc_comment', 'baz');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 71));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 77));
         $expected->add($message);
 
         $message = new Message('text.array_method_call');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 76));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 82));
         $expected->add($message);
 
         $message = new Message('text.var.assign');
         $message->setDesc('The var %foo% should be assigned.');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 82));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 88));
         $expected->add($message);
 
         $this->assertEquals($expected, $catalogue);
@@ -67,9 +69,9 @@ class DefaultPhpFileExtractorTest extends BasePhpFileExtractorTest
 
     public function testExtractTemplate()
     {
-        $expected = new MessageCatalogue();
+        $expected          = new MessageCatalogue();
         $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/template.html.php');
+        $fixtureSplInfo    = new \SplFileInfo(__DIR__ . '/Fixture/template.html.php');
 
         $message = new Message('foo.bar');
         $message->addSource($fileSourceFactory->create($fixtureSplInfo, 1));

--- a/Tests/Translation/Extractor/File/Fixture/Controller.php
+++ b/Tests/Translation/Extractor/File/Fixture/Controller.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -37,7 +39,7 @@ class Controller
     public function __construct(TranslatorInterface $translator, Session $session)
     {
         $this->translator = $translator;
-        $this->session = $session;
+        $this->session    = $session;
     }
 
     public function indexAction()
@@ -47,28 +49,32 @@ class Controller
 
     public function welcomeAction()
     {
-        $this->session->setFlash('bar',
+        $this->session->setFlash(
+            'bar',
             /** @Desc("Welcome %name%! Thanks for signing up.") */
-            $this->translator->trans('text.sign_up_successful', array('name' => 'Johannes')));
+            $this->translator->trans('text.sign_up_successful', ['name' => 'Johannes'])
+        );
     }
 
     public function foobarAction()
     {
-        $this->session->setFlash('archive',
+        $this->session->setFlash(
+            'archive',
             /** @Desc("Archive Message") @Meaning("The verb (to archive), describes an action") */
-            $this->translator->trans('button.archive'));
+            $this->translator->trans('button.archive')
+        );
     }
 
     public function nonExtractableButIgnoredAction()
     {
         /** @Ignore */ $this->translator->trans($foo);
         /** Foobar */
-        /** @Ignore */ $this->translator->trans('foo', array(), $baz);
+        /** @Ignore */ $this->translator->trans('foo', [], $baz);
     }
 
     public function irrelevantDocComment()
     {
-        /** @Foo @Bar */ $this->translator->trans('text.irrelevant_doc_comment', array(), 'baz');
+        /** @Foo @Bar */ $this->translator->trans('text.irrelevant_doc_comment', [], 'baz');
     }
 
     public function arrayAccess()
@@ -79,6 +85,6 @@ class Controller
     public function assignToVar()
     {
         /** @Desc("The var %foo% should be assigned.") */
-        return $this->translator->trans('text.var.assign', array('%foo%' => 'fooVar'));
+        return $this->translator->trans('text.var.assign', ['%foo%' => 'fooVar']);
     }
 }

--- a/Tests/Translation/Extractor/File/Fixture/MyAttrArrayType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyAttrArrayType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -24,15 +27,10 @@ class MyAttrArrayType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $attr = array('something'=>'whatever');
+        $attr = ['something' => 'whatever'];
 
         $builder
-            ->add('firstname', 'text', array(
-                'label' => 'form.label.firstname',
-            ))
-            ->add('field_with_attr_as_array','text',array(
-            'attr'=>$attr
-        ));
+            ->add('firstname', 'text', ['label' => 'form.label.firstname'])
+            ->add('field_with_attr_as_array', 'text', ['attr' => $attr]);
     }
-
 }

--- a/Tests/Translation/Extractor/File/Fixture/MyAuthException.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyAuthException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -26,7 +28,7 @@ class MyAuthException extends AuthenticationException
 
     public function getMessageKey()
     {
-        if (!empty($this->foo)) {
+        if (! empty($this->foo)) {
             /** @Desc("%foo% is invalid.") */
             return 'security.authentication_error.foo';
         }
@@ -37,6 +39,6 @@ class MyAuthException extends AuthenticationException
 
     public function getMessageParameters()
     {
-        return array('foo' => $foo);
+        return ['foo' => $foo];
     }
 }

--- a/Tests/Translation/Extractor/File/Fixture/MyFormModel.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -25,19 +27,17 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class MyFormModel implements TranslationContainerInterface
 {
-    private static $choices = array(
+    private static $choices = [
         'foo' => 'form.label.choice.foo',
         'bar' => 'form.label.choice.bar',
-    );
+    ];
 
-    /**
-     * @Assert\NotBlank(message = "form.error.name_required")
-     */
-    private $name;
+    /** @Assert\NotBlank(message = "form.error.name_required") */
+    public $name;
 
     public static function getTranslationMessages()
     {
-        $messages = array();
+        $messages = [];
 
         foreach (self::$choices as $trans) {
             $message = new Message($trans);

--- a/Tests/Translation/Extractor/File/Fixture/MyFormSubscriber.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormSubscriber.php
@@ -1,10 +1,13 @@
 <?php
+
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\Translation\Extractor\File\Fixture;
 
-use Symfony\Component\Form\Event\DataEvent;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Event\DataEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormFactoryInterface;
 
 class MyFormSubscriber implements EventSubscriberInterface
 {
@@ -19,7 +22,7 @@ class MyFormSubscriber implements EventSubscriberInterface
     {
         // Tells the dispatcher that we want to listen on the form.pre_set_data
         // event and that the preSetData method should be called.
-        return array(FormEvents::PRE_SET_DATA => 'preSetData');
+        return [FormEvents::PRE_SET_DATA => 'preSetData'];
     }
 
     public function preSetData(DataEvent $event)
@@ -27,20 +30,15 @@ class MyFormSubscriber implements EventSubscriberInterface
         $data = $event->getData();
         $form = $event->getForm();
 
-        if (null === $data) {
+        if ($data === null) {
             return;
         }
 
         $form
-            ->add($this->factory->createNamed('password', 'repeated', null, array(
-                'first_options' => array(
-                  'label' => 'form.label.password'
-                ),
-                'second_options' => array(
-                  'label' => /** @Desc("Repeat password") */ 'form.label.password_repeated'
-                ),
-                'invalid_message' => /** @Desc("The entered passwords do not match") */ 'form.error.password_mismatch'
-            )))
-        ;
+            ->add($this->factory->createNamed('password', 'repeated', null, [
+                'first_options' => ['label' => 'form.label.password'],
+                'second_options' => ['label' => /** @Desc("Repeat password") */ 'form.label.password_repeated'],
+                'invalid_message' => /** @Desc("The entered passwords do not match") */ 'form.error.password_mismatch',
+            ]));
     }
 }

--- a/Tests/Translation/Extractor/File/Fixture/MyFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -26,50 +28,38 @@ class MyFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('firstname', 'text', array(
-                'label' => 'form.label.firstname',
-            ))
-            ->add('lastname', 'text', array(
-                'label' => /** @Desc("Lastname") */ 'form.label.lastname',
-            ))
-            ->add('states', 'choice', array(
-                'choices' => array('foo' => 'bar'),
+            ->add('firstname', 'text', ['label' => 'form.label.firstname'])
+            ->add('lastname', 'text', ['label' => /** @Desc("Lastname") */ 'form.label.lastname'])
+            ->add('states', 'choice', [
+                'choices' => ['foo' => 'bar'],
                 'empty_value' => /** @Desc("Please select a state") */ 'form.states.empty_value',
-            ))
-            ->add('countries', 'choice', array('empty_value' => false))
-            ->add('password', 'repeated', array(
-                'first_options' => array(
-                  'label' => 'form.label.password'
-                ),
-                'second_options' => array(
-                  'label' => /** @Desc("Repeat password") */ 'form.label.password_repeated'
-                ),
-                'invalid_message' => /** @Desc("The entered passwords do not match") */ 'form.error.password_mismatch'
-            ))
-            ->add('street', 'text', array(
+            ])
+            ->add('countries', 'choice', ['empty_value' => false])
+            ->add('password', 'repeated', [
+                'first_options' => ['label' => 'form.label.password'],
+                'second_options' => ['label' => /** @Desc("Repeat password") */ 'form.label.password_repeated'],
+                'invalid_message' => /** @Desc("The entered passwords do not match") */ 'form.error.password_mismatch',
+            ])
+            ->add('street', 'text', [
                 'label' => /** @Desc("Street") */ 'form.label.street',
-                'translation_domain' => 'address'
-            ))
-            ->add('zip', 'text', array(
+                'translation_domain' => 'address',
+            ])
+            ->add('zip', 'text', [
                 /** @Desc("ZIP") */
                 'label' => 'form.label.zip',
-                'translation_domain' => 'address'
-            ))
-            ->add('field_with_placeholder', 'text', array(
+                'translation_domain' => 'address',
+            ])
+            ->add('field_with_placeholder', 'text', [
                 'label' => 'field.with.placeholder',
-                'attr' => array('placeholder' => /** @Desc("Field with a placeholder value") */ 'form.placeholder.text')
-            ))
-            ->add('field_without_label', 'text', array(
+                'attr' => ['placeholder' => /** @Desc("Field with a placeholder value") */ 'form.placeholder.text'],
+            ])
+            ->add('field_without_label', 'text', [
                 'label' => false,
-                'attr' => array('placeholder' => /** @Desc("Field with a placeholder but no label") */ 'form.placeholder.text.but.no.label')
-            ))
-        ;
-        $child = $builder->create('created', 'text', array(
-                  'label' => 'form.label.created'
-              ))
-        ;
-        $builder->add('dueDate', 'date', array(
-                'empty_value' => array('year' => 'form.dueDate.empty.year', 'month' => 'form.dueDate.empty.month', 'day'=>'form.dueDate.empty.day')
-        ));
+                'attr' => ['placeholder' => /** @Desc("Field with a placeholder but no label") */ 'form.placeholder.text.but.no.label'],
+            ]);
+        $child = $builder->create('created', 'text', ['label' => 'form.label.created']);
+        $builder->add('dueDate', 'date', [
+            'empty_value' => ['year' => 'form.dueDate.empty.year', 'month' => 'form.dueDate.empty.month', 'day' => 'form.dueDate.empty.day'],
+        ]);
     }
 }

--- a/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithDefaultDomain.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithDefaultDomain.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -27,23 +29,16 @@ class MyFormTypeWithDefaultDomain extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('firstname', 'text', array(
-                'label' => 'form.label.firstname',
-            ))
-            ->add('lastname', 'text', array(
-                'label' => /** @Desc("Lastname") */ 'form.label.lastname',
-            ))
-            ->add('street', 'text', array(
+            ->add('firstname', 'text', ['label' => 'form.label.firstname'])
+            ->add('lastname', 'text', ['label' => /** @Desc("Lastname") */ 'form.label.lastname'])
+            ->add('street', 'text', [
                 'label' => /** @Desc("Street") */ 'form.label.street',
-                'translation_domain' => 'address'
-            ))
-        ;
+                'translation_domain' => 'address',
+            ]);
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'translation_domain' => 'person'
-        ));
+        $resolver->setDefaults(['translation_domain' => 'person']);
     }
 }

--- a/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithDefaultDomainSetDefault.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithDefaultDomainSetDefault.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -27,17 +29,12 @@ class MyFormTypeWithDefaultDomainSetDefault extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('firstname', 'text', array(
-                'label' => 'form.label.firstname',
-            ))
-            ->add('lastname', 'text', array(
-                'label' => /** @Desc("Lastname") */ 'form.label.lastname',
-            ))
-            ->add('street', 'text', array(
+            ->add('firstname', 'text', ['label' => 'form.label.firstname'])
+            ->add('lastname', 'text', ['label' => /** @Desc("Lastname") */ 'form.label.lastname'])
+            ->add('street', 'text', [
                 'label' => /** @Desc("Street") */ 'form.label.street',
-                'translation_domain' => 'address'
-            ))
-        ;
+                'translation_domain' => 'address',
+            ]);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithInterface.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,25 +20,20 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Extractor\File\Fixture;
 
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
 
 class MyFormTypeWithInterface extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('firstname', 'text', array(
-                'label' => 'form.label.firstname',
-            ))
-            ->add('lastname', 'text', array(
-                'label' => /** @Desc("Lastname") */ 'form.label.lastname',
-            ))
-            ->add('states', 'choice', array(
-                'choices' => array('foo' => 'bar'),
+            ->add('firstname', 'text', ['label' => 'form.label.firstname'])
+            ->add('lastname', 'text', ['label' => /** @Desc("Lastname") */ 'form.label.lastname'])
+            ->add('states', 'choice', [
+                'choices' => ['foo' => 'bar'],
                 'empty_value' => /** @Desc("Please select a state") */ 'form.states.empty_value',
-            ))
-            ->add('countries', 'choice', array('empty_value' => false))
-        ;
+            ])
+            ->add('countries', 'choice', ['empty_value' => false]);
     }
 }

--- a/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithSubscriberAndListener.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormTypeWithSubscriberAndListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -20,8 +22,8 @@ namespace JMS\TranslationBundle\Tests\Translation\Extractor\File\Fixture;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 
 class MyFormTypeWithSubscriberAndListener extends AbstractType
 {
@@ -29,31 +31,25 @@ class MyFormTypeWithSubscriberAndListener extends AbstractType
     {
         $formFactory = $builder->getFormFactory();
         $builder
-            ->add('firstname', 'text', array(
-                'label' => 'form.label.firstname',
-            ))
-            ->add('lastname', 'text', array(
-                'label' => /** @Desc("Lastname") */ 'form.label.lastname',
-            ))
+            ->add('firstname', 'text', ['label' => 'form.label.firstname'])
+            ->add('lastname', 'text', ['label' => /** @Desc("Lastname") */ 'form.label.lastname'])
 
             ->addEventSubscriber(new MyFormSubscriber($formFactory))
-            ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($formFactory) {
+            ->addEventListener(FormEvents::PRE_SET_DATA, static function (FormEvent $event) use ($formFactory) {
                 $data = $event->getData();
                 $form = $event->getForm();
 
-                if (null === $data) {
+                if ($data === null) {
                     return;
                 }
 
                 $form
-                    ->add($formFactory->createNamed('zip', 'text', null, array(
+                    ->add($formFactory->createNamed('zip', 'text', null, [
                         /** @Desc("ZIP") */
                         'label' => 'form.label.zip',
-                        'translation_domain' => 'address'
-                    )))
-                ;
-            })
-        ;
+                        'translation_domain' => 'address',
+                    ]));
+            });
     }
 
     public function getName()

--- a/Tests/Translation/Extractor/File/Fixture/MyPlaceholderFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyPlaceholderFormType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -25,20 +28,15 @@ class MyPlaceholderFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('field_with_attr_placeholder', 'text', array(
+            ->add('field_with_attr_placeholder', 'text', [
                 'label' => 'field.with.placeholder',
-                'attr' => array('placeholder' => /** @Desc("Field with a placeholder value") */ 'form.placeholder.text')
-            ))
-            ->add('field_without_label_with_attr_placeholder', 'text', array(
+                'attr' => ['placeholder' => /** @Desc("Field with a placeholder value") */ 'form.placeholder.text'],
+            ])
+            ->add('field_without_label_with_attr_placeholder', 'text', [
                 'label' => false,
-                'attr' => array('placeholder' => /** @Desc("Field with a placeholder but no label") */ 'form.placeholder.text.but.no.label')
-            ))
-            ->add('field_placeholder', 'choice', array(
-                'placeholder' => /** @Desc("Choice field with a placeholder") */ 'form.choice_placeholder'
-            ))
-            ->add('field_empty_value', 'choice', array(
-                'empty_value' => /** @Desc("Choice field with an empty_value") */ 'form.choice_empty_value'
-            ))
-        ;
+                'attr' => ['placeholder' => /** @Desc("Field with a placeholder but no label") */ 'form.placeholder.text.but.no.label'],
+            ])
+            ->add('field_placeholder', 'choice', ['placeholder' => /** @Desc("Choice field with a placeholder") */ 'form.choice_placeholder'])
+            ->add('field_empty_value', 'choice', ['empty_value' => /** @Desc("Choice field with an empty_value") */ 'form.choice_empty_value']);
     }
 }

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,10 +20,9 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Extractor\File;
 
-use JMS\TranslationBundle\Translation\Extractor\File\FormExtractor;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
-use Symfony\Component\HttpKernel\Kernel;
+use JMS\TranslationBundle\Translation\Extractor\File\FormExtractor;
 
 class FormExtractorTest extends BasePhpFileExtractorTest
 {
@@ -30,27 +31,27 @@ class FormExtractorTest extends BasePhpFileExtractorTest
      */
     public function testPlaceholderExtract()
     {
-        $expected = new MessageCatalogue();
+        $expected          = new MessageCatalogue();
         $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyPlaceholderFormType.php');
+        $fixtureSplInfo    = new \SplFileInfo(__DIR__ . '/Fixture/MyPlaceholderFormType.php');
 
         $message = new Message('field.with.placeholder');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 29));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 32));
         $expected->add($message);
 
         $message = new Message('form.placeholder.text');
         $message->setDesc('Field with a placeholder value');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 30));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 33));
         $expected->add($message);
 
         $message = new Message('form.placeholder.text.but.no.label');
         $message->setDesc('Field with a placeholder but no label');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 34));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 37));
         $expected->add($message);
 
         $message = new Message('form.choice_placeholder');
         $message->setDesc('Choice field with a placeholder');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 37));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 39));
         $expected->add($message);
 
         $message = new Message('form.choice_empty_value');
@@ -66,80 +67,80 @@ class FormExtractorTest extends BasePhpFileExtractorTest
      */
     public function testExtract()
     {
-        $expected = new MessageCatalogue();
+        $expected          = new MessageCatalogue();
         $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyFormType.php');
+        $fixtureSplInfo    = new \SplFileInfo(__DIR__ . '/Fixture/MyFormType.php');
 
         $message = new Message('foo');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 36));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 34));
         $expected->add($message);
 
         $message = new Message('form.states.empty_value');
         $message->setDesc('Please select a state');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 37));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 35));
         $expected->add($message);
 
         $message = new Message('form.label.lastname');
         $message->setDesc('Lastname');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 33));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 32));
         $expected->add($message);
 
         $message = new Message('form.label.firstname');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 30));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 31));
         $expected->add($message);
 
         $message = new Message('form.label.password');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 42));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 39));
         $expected->add($message);
 
         $message = new Message('form.label.password_repeated');
         $message->setDesc('Repeat password');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 45));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 40));
         $expected->add($message);
 
         $message = new Message('form.label.street', 'address');
         $message->setDesc('Street');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 50));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 44));
         $expected->add($message);
 
         $message = new Message('form.label.zip', 'address');
         $message->setDesc('ZIP');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 55));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 49));
         $expected->add($message);
 
         $message = new Message('form.error.password_mismatch', 'validators');
         $message->setDesc('The entered passwords do not match');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 47));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 41));
         $expected->add($message);
 
         $message = new Message('form.label.created');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 68));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 60));
         $expected->add($message);
 
         $message = new Message('field.with.placeholder');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 59));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 53));
         $expected->add($message);
 
         $message = new Message('form.placeholder.text');
         $message->setDesc('Field with a placeholder value');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 60));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 54));
         $expected->add($message);
 
         $message = new Message('form.placeholder.text.but.no.label');
         $message->setDesc('Field with a placeholder but no label');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 64));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 58));
         $expected->add($message);
 
         $message = new Message('form.dueDate.empty.year');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 72));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 62));
         $expected->add($message);
 
         $message = new Message('form.dueDate.empty.month');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 72));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 62));
         $expected->add($message);
 
         $message = new Message('form.dueDate.empty.day');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 72));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 62));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('MyFormType.php'));
@@ -147,22 +148,22 @@ class FormExtractorTest extends BasePhpFileExtractorTest
 
     protected function getDefaultDomainFixture($fixtureFile)
     {
-        $expected = new MessageCatalogue();
+        $expected          = new MessageCatalogue();
         $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo($fixtureFile);
+        $fixtureSplInfo    = new \SplFileInfo($fixtureFile);
 
         $message = new Message('form.label.lastname', 'person');
         $message->setDesc('Lastname');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 34));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 33));
         $expected->add($message);
 
         $message = new Message('form.label.firstname', 'person');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 31));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 32));
         $expected->add($message);
 
         $message = new Message('form.label.street', 'address');
         $message->setDesc('Street');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 37));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 35));
         $expected->add($message);
 
         return $expected;
@@ -174,7 +175,7 @@ class FormExtractorTest extends BasePhpFileExtractorTest
      */
     public function testExtractWithDefaultDomain()
     {
-        $this->assertEquals($this->getDefaultDomainFixture(__DIR__.'/Fixture/MyFormTypeWithDefaultDomain.php'), $this->extract('MyFormTypeWithDefaultDomain.php'));
+        $this->assertEquals($this->getDefaultDomainFixture(__DIR__ . '/Fixture/MyFormTypeWithDefaultDomain.php'), $this->extract('MyFormTypeWithDefaultDomain.php'));
     }
 
     /**
@@ -183,7 +184,7 @@ class FormExtractorTest extends BasePhpFileExtractorTest
      */
     public function testExtractWithDefaultDomainSetDefault()
     {
-        $this->assertEquals($this->getDefaultDomainFixture(__DIR__.'/Fixture/MyFormTypeWithDefaultDomainSetDefault.php'), $this->extract('MyFormTypeWithDefaultDomainSetDefault.php'));
+        $this->assertEquals($this->getDefaultDomainFixture(__DIR__ . '/Fixture/MyFormTypeWithDefaultDomainSetDefault.php'), $this->extract('MyFormTypeWithDefaultDomainSetDefault.php'));
     }
 
     /**
@@ -192,22 +193,22 @@ class FormExtractorTest extends BasePhpFileExtractorTest
      */
     public function testExtractWithWithSubscriberAndListener()
     {
-        $expected = new MessageCatalogue();
-        $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyFormTypeWithSubscriberAndListener.php');
-        $subscriberFixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyFormSubscriber.php');
+        $expected                 = new MessageCatalogue();
+        $fileSourceFactory        = $this->getFileSourceFactory();
+        $fixtureSplInfo           = new \SplFileInfo(__DIR__ . '/Fixture/MyFormTypeWithSubscriberAndListener.php');
+        $subscriberFixtureSplInfo = new \SplFileInfo(__DIR__ . '/Fixture/MyFormSubscriber.php');
 
         $message = new Message('form.label.lastname');
         $message->setDesc('Lastname');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 36));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 35));
         $expected->add($message);
 
         $message = new Message('form.label.firstname');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 33));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 34));
         $expected->add($message);
 
         $message = new Message('form.label.password');
-        $message->addSource($fileSourceFactory->create($subscriberFixtureSplInfo, 37));
+        $message->addSource($fileSourceFactory->create($subscriberFixtureSplInfo, 39));
         $expected->add($message);
 
         $message = new Message('form.label.password_repeated');
@@ -217,12 +218,12 @@ class FormExtractorTest extends BasePhpFileExtractorTest
 
         $message = new Message('form.label.zip', 'address');
         $message->setDesc('ZIP');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 51));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 49));
         $expected->add($message);
 
         $message = new Message('form.error.password_mismatch', 'validators');
         $message->setDesc('The entered passwords do not match');
-        $message->addSource($fileSourceFactory->create($subscriberFixtureSplInfo, 42));
+        $message->addSource($fileSourceFactory->create($subscriberFixtureSplInfo, 41));
         $expected->add($message);
 
         $catalogue = $this->extract('MyFormTypeWithSubscriberAndListener.php');
@@ -244,16 +245,15 @@ class FormExtractorTest extends BasePhpFileExtractorTest
 
     public function testAttrArrayForm()
     {
-        $expected = new MessageCatalogue();
+        $expected          = new MessageCatalogue();
         $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/MyAttrArrayType.php');
+        $fixtureSplInfo    = new \SplFileInfo(__DIR__ . '/Fixture/MyAttrArrayType.php');
 
         $message = new Message('form.label.firstname');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 31));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 33));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('MyAttrArrayType.php'));
-
     }
 
     protected function getDefaultExtractor()

--- a/Tests/Translation/Extractor/File/TranslationContainerExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TranslationContainerExtractorTest.php
@@ -48,8 +48,9 @@ class TranslationContainerExtractorTest extends TestCase
 
     private function extract($file, TranslationContainerExtractor $extractor = null)
     {
-        if (!is_file($file = __DIR__.'/Fixture/'.$file)) {
-            throw new RuntimeException(sprintf('The file "%s" does not exist.', $file));
+        $fileRealPath = __DIR__.'/Fixture/'.$file;
+        if (!is_file($fileRealPath)) {
+            throw new RuntimeException(sprintf('The file "%s" does not exist.', $fileRealPath));
         }
 
         if (null === $extractor) {
@@ -64,10 +65,10 @@ class TranslationContainerExtractorTest extends TestCase
             $parser = new Parser($lexer);
         }
 
-        $ast = $parser->parse(file_get_contents($file));
+        $ast = $parser->parse(file_get_contents($fileRealPath));
 
         $catalogue = new MessageCatalogue();
-        $extractor->visitPhpFile(new \SplFileInfo($file), $catalogue, $ast);
+        $extractor->visitPhpFile(new \SplFileInfo($fileRealPath), $catalogue, $ast);
 
         return $catalogue;
     }

--- a/Tests/Translation/Extractor/File/TranslationContainerExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TranslationContainerExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -21,8 +23,8 @@ namespace JMS\TranslationBundle\Tests\Translation\Extractor\File;
 use JMS\TranslationBundle\Exception\RuntimeException;
 use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
-use JMS\TranslationBundle\Translation\Extractor\File\TranslationContainerExtractor;
 use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\Extractor\File\TranslationContainerExtractor;
 use PhpParser\Lexer;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
@@ -33,7 +35,7 @@ class TranslationContainerExtractorTest extends TestCase
     public function testExtractFormModel()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/MyFormModel.php';
+        $path     = __DIR__ . '/Fixture/MyFormModel.php';
 
         $message = new Message('form.label.choice.foo');
         $message->addSource(new FileSource($path, 13));
@@ -46,21 +48,21 @@ class TranslationContainerExtractorTest extends TestCase
         $this->assertEquals($expected, $this->extract('MyFormModel.php'));
     }
 
-    private function extract($file, TranslationContainerExtractor $extractor = null)
+    private function extract($file, ?TranslationContainerExtractor $extractor = null)
     {
-        $fileRealPath = __DIR__.'/Fixture/'.$file;
-        if (!is_file($fileRealPath)) {
+        $fileRealPath = __DIR__ . '/Fixture/' . $file;
+        if (! is_file($fileRealPath)) {
             throw new RuntimeException(sprintf('The file "%s" does not exist.', $fileRealPath));
         }
 
-        if (null === $extractor) {
+        if ($extractor === null) {
             $extractor = new TranslationContainerExtractor();
         }
 
         $lexer = new Lexer();
         if (class_exists('PhpParser\ParserFactory')) {
             $factory = new ParserFactory();
-            $parser = $factory->create(ParserFactory::PREFER_PHP7, $lexer);
+            $parser  = $factory->create(ParserFactory::PREFER_PHP7, $lexer);
         } else {
             $parser = new Parser($lexer);
         }

--- a/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -42,9 +44,9 @@ class TwigFileExtractorTest extends TestCase
 {
     public function testExtractSimpleTemplate()
     {
-        $expected = new MessageCatalogue();
+        $expected          = new MessageCatalogue();
         $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/simple_template.html.twig');
+        $fixtureSplInfo    = new \SplFileInfo(__DIR__ . '/Fixture/simple_template.html.twig');
 
         $message = new Message('text.foo');
         $message->setDesc('Foo Bar');
@@ -99,15 +101,15 @@ class TwigFileExtractorTest extends TestCase
 
     public function testExtractEdit()
     {
-        $expected = new MessageCatalogue();
+        $expected          = new MessageCatalogue();
         $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/edit.html.twig');
+        $fixtureSplInfo    = new \SplFileInfo(__DIR__ . '/Fixture/edit.html.twig');
 
         $message = new Message('header.edit_profile');
         $message->addSource($fileSourceFactory->create($fixtureSplInfo, 10));
         $expected->add($message);
 
-        $message = new Message("text.archive");
+        $message = new Message('text.archive');
         $message->setDesc('Archive');
         $message->setMeaning('The verb');
         $message->addSource($fileSourceFactory->create($fixtureSplInfo, 13));
@@ -127,9 +129,9 @@ class TwigFileExtractorTest extends TestCase
 
     public function testEmbeddedTemplate()
     {
-        $expected = new MessageCatalogue();
+        $expected          = new MessageCatalogue();
         $fileSourceFactory = $this->getFileSourceFactory();
-        $fixtureSplInfo = new \SplFileInfo(__DIR__.'/Fixture/embedded_template.html.twig');
+        $fixtureSplInfo    = new \SplFileInfo(__DIR__ . '/Fixture/embedded_template.html.twig');
 
         $message = new Message('foo');
         $message->addSource($fileSourceFactory->create($fixtureSplInfo, 3));
@@ -138,14 +140,14 @@ class TwigFileExtractorTest extends TestCase
         $this->assertEquals($expected, $this->extract('embedded_template.html.twig'));
     }
 
-    private function extract($file, TwigFileExtractor $extractor = null)
+    private function extract($file, ?TwigFileExtractor $extractor = null)
     {
-        $fileRealPath = __DIR__.'/Fixture/'.$file;
-        if (!is_file($fileRealPath)) {
+        $fileRealPath = __DIR__ . '/Fixture/' . $file;
+        if (! is_file($fileRealPath)) {
             throw new RuntimeException(sprintf('The file "%s" does not exist.', $fileRealPath));
         }
 
-        $env = new Environment(new ArrayLoader(array()));
+        $env = new Environment(new ArrayLoader([]));
         $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator()));
         $env->addExtension(new TranslationExtension($translator, true));
         $env->addExtension(new RoutingExtension(new UrlGenerator(new RouteCollection(), new RequestContext())));
@@ -155,12 +157,15 @@ class TwigFileExtractorTest extends TestCase
             if ($visitor instanceof DefaultApplyingNodeVisitor) {
                 $visitor->setEnabled(false);
             }
-            if ($visitor instanceof RemovingNodeVisitor) {
-                $visitor->setEnabled(false);
+
+            if (! ($visitor instanceof RemovingNodeVisitor)) {
+                continue;
             }
+
+            $visitor->setEnabled(false);
         }
 
-        if (null === $extractor) {
+        if ($extractor === null) {
             $extractor = new TwigFileExtractor($env, new FileSourceFactory('faux'));
         }
 

--- a/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
@@ -140,8 +140,9 @@ class TwigFileExtractorTest extends TestCase
 
     private function extract($file, TwigFileExtractor $extractor = null)
     {
-        if (!is_file($file = __DIR__.'/Fixture/'.$file)) {
-            throw new RuntimeException(sprintf('The file "%s" does not exist.', $file));
+        $fileRealPath = __DIR__.'/Fixture/'.$file;
+        if (!is_file($fileRealPath)) {
+            throw new RuntimeException(sprintf('The file "%s" does not exist.', $fileRealPath));
         }
 
         $env = new Environment(new ArrayLoader(array()));
@@ -163,10 +164,10 @@ class TwigFileExtractorTest extends TestCase
             $extractor = new TwigFileExtractor($env, new FileSourceFactory('faux'));
         }
 
-        $ast = $env->parse($env->tokenize(new Source(file_get_contents($file), $file)));
+        $ast = $env->parse($env->tokenize(new Source(file_get_contents($fileRealPath), $fileRealPath)));
 
         $catalogue = new MessageCatalogue();
-        $extractor->visitTwigFile(new \SplFileInfo($file), $catalogue, $ast);
+        $extractor->visitTwigFile(new \SplFileInfo($fileRealPath), $catalogue, $ast);
 
         return $catalogue;
     }

--- a/Tests/Translation/Extractor/File/ValidationExtractorTest.php
+++ b/Tests/Translation/Extractor/File/ValidationExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,28 +20,24 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Extractor\File;
 
-use JMS\TranslationBundle\Exception\RuntimeException;
 use Doctrine\Common\Annotations\AnnotationReader;
+use JMS\TranslationBundle\Exception\RuntimeException;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\Extractor\File\ValidationExtractor;
 use PhpParser\Lexer;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
-use Symfony\Component\Validator\Mapping\ClassMetadataFactory;
-use JMS\TranslationBundle\Translation\Extractor\File\ValidationExtractor;
-use Doctrine\Common\Annotations\DocParser;
-use JMS\TranslationBundle\Translation\Extractor\File\FormExtractor;
-use JMS\TranslationBundle\Model\FileSource;
-use JMS\TranslationBundle\Model\Message;
-use JMS\TranslationBundle\Model\MessageCatalogue;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 
 class ValidationExtractorTest extends TestCase
 {
     public function testExtractConstraints()
     {
         $expected = new MessageCatalogue();
-        $path = __DIR__.'/Fixture/MyFormModel.php';
+        $path     = __DIR__ . '/Fixture/MyFormModel.php';
 
         $message = new Message('form.error.name_required', 'validators');
         $expected->add($message);
@@ -47,24 +45,24 @@ class ValidationExtractorTest extends TestCase
         $this->assertEquals($expected, $this->extract('MyFormModel.php'));
     }
 
-    private function extract($file, ValidationExtractor $extractor = null)
+    private function extract($file, ?ValidationExtractor $extractor = null)
     {
-        $fileRealPath = __DIR__.'/Fixture/'.$file;
-        if (!is_file($fileRealPath)) {
+        $fileRealPath = __DIR__ . '/Fixture/' . $file;
+        if (! is_file($fileRealPath)) {
             throw new RuntimeException(sprintf('The file "%s" does not exist.', $fileRealPath));
         }
 
         $metadataFactoryClass = LazyLoadingMetadataFactory::class;
 
-        if (null === $extractor) {
-            $factory = new $metadataFactoryClass(new AnnotationLoader(new AnnotationReader()));
+        if ($extractor === null) {
+            $factory   = new $metadataFactoryClass(new AnnotationLoader(new AnnotationReader()));
             $extractor = new ValidationExtractor($factory);
         }
 
         $lexer = new Lexer();
         if (class_exists('PhpParser\ParserFactory')) {
             $factory = new ParserFactory();
-            $parser = $factory->create(ParserFactory::PREFER_PHP7, $lexer);
+            $parser  = $factory->create(ParserFactory::PREFER_PHP7, $lexer);
         } else {
             $parser = new Parser($lexer);
         }

--- a/Tests/Translation/Extractor/File/ValidationExtractorTest.php
+++ b/Tests/Translation/Extractor/File/ValidationExtractorTest.php
@@ -49,8 +49,9 @@ class ValidationExtractorTest extends TestCase
 
     private function extract($file, ValidationExtractor $extractor = null)
     {
-        if (!is_file($file = __DIR__.'/Fixture/'.$file)) {
-            throw new RuntimeException(sprintf('The file "%s" does not exist.', $file));
+        $fileRealPath = __DIR__.'/Fixture/'.$file;
+        if (!is_file($fileRealPath)) {
+            throw new RuntimeException(sprintf('The file "%s" does not exist.', $fileRealPath));
         }
 
         $metadataFactoryClass = LazyLoadingMetadataFactory::class;
@@ -68,10 +69,10 @@ class ValidationExtractorTest extends TestCase
             $parser = new Parser($lexer);
         }
 
-        $ast = $parser->parse(file_get_contents($file));
+        $ast = $parser->parse(file_get_contents($fileRealPath));
 
         $catalogue = new MessageCatalogue();
-        $extractor->visitPhpFile(new \SplFileInfo($file), $catalogue, $ast);
+        $extractor->visitPhpFile(new \SplFileInfo($fileRealPath), $catalogue, $ast);
 
         return $catalogue;
     }

--- a/Tests/Translation/Extractor/FileExtractorTest.php
+++ b/Tests/Translation/Extractor/FileExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,26 +20,23 @@
 
 namespace JMS\TranslationBundle\Tests\Translation\Extractor;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\DocParser;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\Extractor\File\DefaultPhpFileExtractor;
+use JMS\TranslationBundle\Translation\Extractor\File\FormExtractor;
+use JMS\TranslationBundle\Translation\Extractor\File\TranslationContainerExtractor;
 use JMS\TranslationBundle\Translation\Extractor\File\TwigFileExtractor;
+use JMS\TranslationBundle\Translation\Extractor\File\ValidationExtractor;
+use JMS\TranslationBundle\Translation\Extractor\FileExtractor;
 use JMS\TranslationBundle\Translation\FileSourceFactory;
 use JMS\TranslationBundle\Twig\TranslationExtension;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
-use Doctrine\Common\Annotations\DocParser;
-use JMS\TranslationBundle\Translation\Extractor\File\FormExtractor;
-use Doctrine\Common\Annotations\AnnotationReader;
-use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
-use Symfony\Component\Validator\Mapping\ClassMetadataFactory;
-use JMS\TranslationBundle\Translation\Extractor\File\ValidationExtractor;
-use JMS\TranslationBundle\Model\FileSource;
-use JMS\TranslationBundle\Model\Message;
-use JMS\TranslationBundle\Model\MessageCatalogue;
-use JMS\TranslationBundle\Translation\Extractor\File\TranslationContainerExtractor;
-use JMS\TranslationBundle\Translation\Extractor\File\DefaultPhpFileExtractor;
+use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExtension;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
-use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExtension;
-use JMS\TranslationBundle\Translation\Extractor\FileExtractor;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\Loader\FilesystemLoader;
@@ -46,13 +45,13 @@ class FileExtractorTest extends TestCase
 {
     public function testExtractWithSimpleTestFixtures()
     {
-        $expected = array();
-        $basePath = __DIR__.'/Fixture/SimpleTest/';
+        $expected          = [];
+        $basePath          = __DIR__ . '/Fixture/SimpleTest/';
         $fileSourceFactory = new FileSourceFactory('faux');
 
         // Controller
         $message = new Message('controller.foo');
-        $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'Controller/DefaultController.php'), 27));
+        $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath . 'Controller/DefaultController.php'), 29));
         $message->setDesc('Foo');
         $expected['controller.foo'] = $message;
 
@@ -61,35 +60,35 @@ class FileExtractorTest extends TestCase
         $expected['form.bar'] = new Message('form.bar');
 
         // Templates
-        foreach (array('php', 'twig') as $engine) {
-            $message = new Message($engine.'.foo');
-            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'Resources/views/'.$engine.'_template.html.'.$engine), 1));
-            $expected[$engine.'.foo'] = $message;
+        foreach (['php', 'twig'] as $engine) {
+            $message = new Message($engine . '.foo');
+            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath . 'Resources/views/' . $engine . '_template.html.' . $engine), 1));
+            $expected[$engine . '.foo'] = $message;
 
-            $message = new Message($engine.'.bar');
+            $message = new Message($engine . '.bar');
             $message->setDesc('Bar');
-            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'Resources/views/'.$engine.'_template.html.'.$engine), 3));
-            $expected[$engine.'.bar'] = $message;
+            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath . 'Resources/views/' . $engine . '_template.html.' . $engine), 3));
+            $expected[$engine . '.bar'] = $message;
 
-            $message = new Message($engine.'.baz');
+            $message = new Message($engine . '.baz');
             $message->setMeaning('Baz');
-            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'Resources/views/'.$engine.'_template.html.'.$engine), 5));
-            $expected[$engine.'.baz'] = $message;
+            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath . 'Resources/views/' . $engine . '_template.html.' . $engine), 5));
+            $expected[$engine . '.baz'] = $message;
 
-            $message = new Message($engine.'.foo_bar');
+            $message = new Message($engine . '.foo_bar');
             $message->setDesc('Foo');
             $message->setMeaning('Bar');
-            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'Resources/views/'.$engine.'_template.html.'.$engine), 7));
-            $expected[$engine.'.foo_bar'] = $message;
+            $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath . 'Resources/views/' . $engine . '_template.html.' . $engine), 7));
+            $expected[$engine . '.foo_bar'] = $message;
         }
 
         // File with global namespace.
         $message = new Message('globalnamespace.foo');
-        $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath.'GlobalNamespace.php'), 27));
+        $message->addSource($fileSourceFactory->create(new \SplFileInfo($basePath . 'GlobalNamespace.php'), 29));
         $message->setDesc('Bar');
         $expected['globalnamespace.foo'] = $message;
 
-        $actual = $this->extract(__DIR__.'/Fixture/SimpleTest')->getDomain('messages')->all();
+        $actual = $this->extract(__DIR__ . '/Fixture/SimpleTest')->getDomain('messages')->all();
 
         asort($expected);
         asort($actual);
@@ -99,18 +98,18 @@ class FileExtractorTest extends TestCase
 
     private function extract($directory)
     {
-        $twig = new Environment(new ArrayLoader(array()));
+        $twig = new Environment(new ArrayLoader([]));
         $twig->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator()));
         $twig->addExtension(new TranslationExtension($translator));
-        $loader=new FilesystemLoader(realpath(__DIR__."/Fixture/SimpleTest/Resources/views/"));
+        $loader =new FilesystemLoader(realpath(__DIR__ . '/Fixture/SimpleTest/Resources/views/'));
         $twig->setLoader($loader);
 
         $docParser = new DocParser();
-        $docParser->setImports(array(
-                        'desc' => 'JMS\TranslationBundle\Annotation\Desc',
-                        'meaning' => 'JMS\TranslationBundle\Annotation\Meaning',
-                        'ignore' => 'JMS\TranslationBundle\Annotation\Ignore',
-        ));
+        $docParser->setImports([
+            'desc' => 'JMS\TranslationBundle\Annotation\Desc',
+            'meaning' => 'JMS\TranslationBundle\Annotation\Meaning',
+            'ignore' => 'JMS\TranslationBundle\Annotation\Ignore',
+        ]);
         $docParser->setIgnoreNotImportedAnnotations(true);
 
         $metadataFactoryClass = LazyLoadingMetadataFactory::class;
@@ -119,13 +118,13 @@ class FileExtractorTest extends TestCase
 
         $dummyFileSourceFactory = new FileSourceFactory('faux');
 
-        $extractor = new FileExtractor($twig, new NullLogger(), array(
+        $extractor = new FileExtractor($twig, new NullLogger(), [
             new DefaultPhpFileExtractor($docParser, $dummyFileSourceFactory),
             new TranslationContainerExtractor(),
             new TwigFileExtractor($twig, $dummyFileSourceFactory),
             new ValidationExtractor($factory),
             new FormExtractor($docParser, $dummyFileSourceFactory),
-        ));
+        ]);
         $extractor->setDirectory($directory);
 
         return $extractor->extract();

--- a/Tests/Translation/Extractor/Fixture/SimpleTest/Controller/DefaultController.php
+++ b/Tests/Translation/Extractor/Fixture/SimpleTest/Controller/DefaultController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/Tests/Translation/Extractor/Fixture/SimpleTest/Form/FormModel.php
+++ b/Tests/Translation/Extractor/Fixture/SimpleTest/Form/FormModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -25,9 +27,9 @@ class FormModel implements TranslationContainerInterface
 {
     public static function getTranslationMessages()
     {
-        return array(
+        return [
             new Message('form.foo'),
             new Message('form.bar'),
-        );
+        ];
     }
 }

--- a/Tests/Translation/Extractor/Fixture/SimpleTest/GlobalNamespace.php
+++ b/Tests/Translation/Extractor/Fixture/SimpleTest/GlobalNamespace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,7 +20,7 @@
 
 namespace
 {
-    class SomeRandomClassNameWhichIsnTUsedAnywhereJMSTranslatorTest
+    class GlobalNamespace
     {
         private $translator;
 

--- a/Tests/Translation/ExtractorManagerTest.php
+++ b/Tests/Translation/ExtractorManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -20,13 +22,12 @@ namespace JMS\TranslationBundle\Tests\Translation;
 
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
-use PHPUnit\Framework\TestCase;
-use Psr\Log\NullLogger;
 use JMS\TranslationBundle\Translation\Extractor\FileExtractor;
 use JMS\TranslationBundle\Translation\ExtractorManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
-use JMS\TranslationBundle\Translation\ExtractorInterface;
 
 class ExtractorManagerTest extends TestCase
 {
@@ -36,7 +37,7 @@ class ExtractorManagerTest extends TestCase
         $this->expectExceptionMessage('There is no extractor with alias "foo". Available extractors: # none #');
 
         $manager = $this->getManager();
-        $manager->setEnabledExtractors(array('foo' => true));
+        $manager->setEnabledExtractors(['foo' => true]);
     }
 
     public function testOnlySomeExtractorsEnabled()
@@ -44,8 +45,7 @@ class ExtractorManagerTest extends TestCase
         $foo = $this->createMock('JMS\TranslationBundle\Translation\ExtractorInterface');
         $foo
             ->expects($this->never())
-            ->method('extract')
-        ;
+            ->method('extract');
 
         $catalogue = new MessageCatalogue();
         $catalogue->add(new Message('foo'));
@@ -53,32 +53,29 @@ class ExtractorManagerTest extends TestCase
         $bar
             ->expects($this->once())
             ->method('extract')
-            ->willReturn($catalogue)
-        ;
+            ->willReturn($catalogue);
 
-        $manager = $this->getManager(null, array(
+        $manager = $this->getManager(null, [
             'foo' => $foo,
             'bar' => $bar,
-        ));
-        $manager->setEnabledExtractors(array('bar' => true));
+        ]);
+        $manager->setEnabledExtractors(['bar' => true]);
 
         $this->assertEquals($catalogue, $manager->extract());
     }
 
     public function testReset()
     {
-        $foo = $this->createMock('JMS\TranslationBundle\Translation\ExtractorInterface');
+        $foo    = $this->createMock('JMS\TranslationBundle\Translation\ExtractorInterface');
         $logger = new NullLogger();
 
-        $extractor = new FileExtractor(new Environment(new ArrayLoader(array())), $logger, array());
-        $extractor->setExcludedNames(array('foo', 'bar'));
-        $extractor->setExcludedDirs(array('baz'));
+        $extractor = new FileExtractor(new Environment(new ArrayLoader([])), $logger, []);
+        $extractor->setExcludedNames(['foo', 'bar']);
+        $extractor->setExcludedDirs(['baz']);
 
-        $manager = $this->getManager($extractor, array(
-            'foo' => $foo,
-        ));
-        $manager->setEnabledExtractors(array('foo' => true));
-        $manager->setDirectories(array('/'));
+        $manager = $this->getManager($extractor, ['foo' => $foo]);
+        $manager->setEnabledExtractors(['foo' => true]);
+        $manager->setDirectories(['/']);
 
         $managerReflection   = new \ReflectionClass($manager);
         $extractorReflection = new \ReflectionClass($extractor);
@@ -95,25 +92,25 @@ class ExtractorManagerTest extends TestCase
         $excludedDirsProperty = $extractorReflection->getProperty('excludedDirs');
         $excludedDirsProperty->setAccessible(true);
 
-        $this->assertEquals(array('foo' => true), $enabledExtractorsProperty->getValue($manager));
-        $this->assertEquals(array('/'), $directoriesProperty->getValue($manager));
-        $this->assertEquals(array('foo', 'bar'), $excludedNamesProperty->getValue($extractor));
-        $this->assertEquals(array('baz'), $excludedDirsProperty->getValue($extractor));
+        $this->assertEquals(['foo' => true], $enabledExtractorsProperty->getValue($manager));
+        $this->assertEquals(['/'], $directoriesProperty->getValue($manager));
+        $this->assertEquals(['foo', 'bar'], $excludedNamesProperty->getValue($extractor));
+        $this->assertEquals(['baz'], $excludedDirsProperty->getValue($extractor));
 
         $manager->reset();
 
-        $this->assertEquals(array(), $enabledExtractorsProperty->getValue($manager));
-        $this->assertEquals(array(), $directoriesProperty->getValue($manager));
-        $this->assertEquals(array(), $excludedNamesProperty->getValue($extractor));
-        $this->assertEquals(array(), $excludedDirsProperty->getValue($extractor));
+        $this->assertEquals([], $enabledExtractorsProperty->getValue($manager));
+        $this->assertEquals([], $directoriesProperty->getValue($manager));
+        $this->assertEquals([], $excludedNamesProperty->getValue($extractor));
+        $this->assertEquals([], $excludedDirsProperty->getValue($extractor));
     }
 
-    private function getManager(FileExtractor $extractor = null, array $extractors = array())
+    private function getManager(?FileExtractor $extractor = null, array $extractors = [])
     {
         $logger = new NullLogger();
 
-        if (null === $extractor) {
-            $extractor = new FileExtractor(new Environment(new ArrayLoader(array())), $logger, array());
+        if ($extractor === null) {
+            $extractor = new FileExtractor(new Environment(new ArrayLoader([])), $logger, []);
         }
 
         return new ExtractorManager($extractor, $logger, $extractors);

--- a/Tests/Translation/FileSourceFactoryTest.php
+++ b/Tests/Translation/FileSourceFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JMS\TranslationBundle\Tests\Translation;
 
 use JMS\TranslationBundle\Translation\FileSourceFactory;
@@ -16,74 +18,74 @@ class FileSourceFactoryTest extends TestCase
     public function testGetRelativePath($root, $projectRoot, $file, $expected, $message = '')
     {
         $factory = new FileSourceFactory($root, $projectRoot);
-        $result = NSA::invokeMethod($factory, 'getRelativePath', $file);
+        $result  = NSA::invokeMethod($factory, 'getRelativePath', $file);
 
         $this->assertEquals($expected, $result, $message);
     }
 
     public function pathProvider()
     {
-        return array(
-            array(
+        return [
+            [
                 '/user/foo/application/app',
                 null,
                 '/user/foo/application/src/bundle/controller/index.php',
                 '/../src/bundle/controller/index.php',
-            ),
+            ],
 
-            array(
+            [
                 '/user/foo/application/app/foo/bar',
                 null,
                 '/user/foo/application/src/bundle/controller/index.php',
                 '/../../../src/bundle/controller/index.php',
-            ),
+            ],
 
-            array(
+            [
                 '/user/foo/application/app',
                 null,
                 '/user/foo/application/app/../src/AppBundle/Controller/DefaultController.php',
                 '/../src/AppBundle/Controller/DefaultController.php',
                 'Test with "/../" in the file path',
-            ),
+            ],
 
-            array(
+            [
                 '/user/foo/application/app/foo/bar/baz/biz/foo',
                 null,
                 '/user/foo/application/src/bundle/controller/index.php',
                 '/../../../../../../src/bundle/controller/index.php',
                 'Test when the root path is longer that file path',
-            ),
+            ],
 
-            array(
+            [
                 '/user/foo/application/app',
                 '/user/foo/application',
                 '/user/foo/application/src/bundle/controller/index.php',
                 '/src/bundle/controller/index.php',
-            ),
+            ],
 
-            array(
+            [
                 '/user/foo/application/app/foo/bar',
                 '/user/foo/application/src/foo/bar',
                 '/user/foo/application/src/bundle/controller/index.php',
                 '/../../bundle/controller/index.php',
-            ),
+            ],
 
-            array(
+            [
                 '/user/foo/application/app',
                 '/user/foo/application',
                 '/user/foo/application/app/../src/AppBundle/Controller/DefaultController.php',
                 '/app/../src/AppBundle/Controller/DefaultController.php',
                 'Test with "/../" in the file path',
-            ),
+            ],
 
-            array(
+            [
                 '/user/foo/application/app/foo/bar/baz/biz/foo',
                 '/user/foo/application/src/foo/bar/baz/biz/foo',
                 '/user/foo/application/src/bundle/controller/index.php',
                 '/../../../../../bundle/controller/index.php',
                 'Test when the root path is longer that file path',
-            ),
+            ],
 
-        );
+        ];
     }
 }

--- a/Tests/Translation/FileWriterTest.php
+++ b/Tests/Translation/FileWriterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -33,14 +35,11 @@ class FileWriterTest extends TestCase
         $dumper
             ->expects($this->once())
             ->method('dump')
-            ->willReturnCallback(function ($v) use ($self) {
-                $self->assertEquals(array('foo.bar', 'foo.bar.baz'), array_keys($v->getDomain('messages')->all()));
-            })
-        ;
+            ->willReturnCallback(static function ($v) use ($self) {
+                $self->assertEquals(['foo.bar', 'foo.bar.baz'], array_keys($v->getDomain('messages')->all()));
+            });
 
-        $writer = new FileWriter(array(
-            'test' => $dumper,
-        ));
+        $writer = new FileWriter(['test' => $dumper]);
 
         $catalogue = new MessageCatalogue();
         $catalogue->setLocale('fr');

--- a/Tests/Translation/Loader/Symfony/BaseLoaderTest.php
+++ b/Tests/Translation/Loader/Symfony/BaseLoaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -27,7 +29,7 @@ abstract class BaseLoaderTest extends TestCase
     public function testLoadSimple()
     {
         $expected = new MessageCatalogue('en');
-        $expected->add(array('foo' => 'foo'));
+        $expected->add(['foo' => 'foo']);
 
         $file = $this->getInputFile('simple');
         $expected->addResource(new FileResource($file));
@@ -38,11 +40,11 @@ abstract class BaseLoaderTest extends TestCase
     public function testLoadStructureWithMetadata()
     {
         $expected = new MessageCatalogue('en');
-        $expected->add(array(
+        $expected->add([
             'foo.bar.baz' => 'Foo',
             'foo.bar.moo' => 'foo.bar.moo',
             'foo.baz' => 'foo.baz',
-        ));
+        ]);
 
         $file = $this->getInputFile('structure_with_metadata');
         $expected->addResource(new FileResource($file));
@@ -53,9 +55,7 @@ abstract class BaseLoaderTest extends TestCase
     public function testLoadStructure()
     {
         $expected = new MessageCatalogue('en');
-        $expected->add(array(
-            'foo.bar.baz' => 'foo.bar.baz',
-        ));
+        $expected->add(['foo.bar.baz' => 'foo.bar.baz']);
 
         $file = $this->getInputFile('structure');
         $expected->addResource(new FileResource($file));
@@ -66,9 +66,7 @@ abstract class BaseLoaderTest extends TestCase
     public function testLoadWithMetadata()
     {
         $expected = new MessageCatalogue('en');
-        $expected->add(array(
-            'foo' => 'bar',
-        ));
+        $expected->add(['foo' => 'bar']);
 
         $file = $this->getInputFile('with_metadata');
         $expected->addResource(new FileResource($file));
@@ -77,6 +75,7 @@ abstract class BaseLoaderTest extends TestCase
     }
 
     abstract protected function getLoader();
+
     abstract protected function getInputFile($key);
 
     private function load($file, $locale = 'en')

--- a/Tests/Translation/Loader/Symfony/PhpLoaderTest.php
+++ b/Tests/Translation/Loader/Symfony/PhpLoaderTest.php
@@ -30,10 +30,11 @@ class PhpLoaderTest extends BaseLoaderTest
 
     protected function getInputFile($key)
     {
-        if (!is_file($file = __DIR__.'/../../Dumper/php/'.$key.'.php')) {
+        $fileRealPath =  __DIR__.'/../../Dumper/php/'.$key.'.php';
+        if (!is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('The input file for key "%s" does not exist.', $key));
         }
 
-        return $file;
+        return $fileRealPath;
     }
 }

--- a/Tests/Translation/Loader/Symfony/PhpLoaderTest.php
+++ b/Tests/Translation/Loader/Symfony/PhpLoaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -30,8 +32,8 @@ class PhpLoaderTest extends BaseLoaderTest
 
     protected function getInputFile($key)
     {
-        $fileRealPath =  __DIR__.'/../../Dumper/php/'.$key.'.php';
-        if (!is_file($fileRealPath)) {
+        $fileRealPath =  __DIR__ . '/../../Dumper/php/' . $key . '.php';
+        if (! is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('The input file for key "%s" does not exist.', $key));
         }
 

--- a/Tests/Translation/Loader/Symfony/XliffLoaderTest.php
+++ b/Tests/Translation/Loader/Symfony/XliffLoaderTest.php
@@ -43,11 +43,12 @@ class XliffLoaderTest extends BaseLoaderTest
 
     protected function getInputFile($key)
     {
-        if (!is_file($file = __DIR__.'/../../Dumper/xliff/'.$key.'.xml')) {
+        $fileRealPath =  __DIR__.'/../../Dumper/xliff/'.$key.'.xml';
+        if (!is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('The input file for key "%s" does not exist.', $key));
         }
 
-        return $file;
+        return $fileRealPath;
     }
 
     protected function getLoader()

--- a/Tests/Translation/Loader/Symfony/XliffLoaderTest.php
+++ b/Tests/Translation/Loader/Symfony/XliffLoaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -19,23 +21,23 @@
 namespace JMS\TranslationBundle\Tests\Translation\Loader\Symfony;
 
 use JMS\TranslationBundle\Exception\InvalidArgumentException;
+use JMS\TranslationBundle\Translation\Loader\Symfony\XliffLoader;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Translation\MessageCatalogue;
-use JMS\TranslationBundle\Translation\Loader\Symfony\XliffLoader;
 
 class XliffLoaderTest extends BaseLoaderTest
 {
     public function testLoadOldFormat()
     {
         $expected = new MessageCatalogue('en');
-        $expected->add(array(
+        $expected->add([
             'foo1' => 'bar',
             'foo2' => 'bar',
             'foo3' => 'bar',
             'foo4' => 'bar',
-        ));
+        ]);
 
-        $file = __DIR__.'/xliff/old_format.xml';
+        $file = __DIR__ . '/xliff/old_format.xml';
         $expected->addResource(new FileResource($file));
 
         $this->assertEquals($expected, $this->getLoader()->load($file, 'en'));
@@ -43,8 +45,8 @@ class XliffLoaderTest extends BaseLoaderTest
 
     protected function getInputFile($key)
     {
-        $fileRealPath =  __DIR__.'/../../Dumper/xliff/'.$key.'.xml';
-        if (!is_file($fileRealPath)) {
+        $fileRealPath =  __DIR__ . '/../../Dumper/xliff/' . $key . '.xml';
+        if (! is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('The input file for key "%s" does not exist.', $key));
         }
 

--- a/Tests/Translation/Loader/Symfony/YamlLoaderTest.php
+++ b/Tests/Translation/Loader/Symfony/YamlLoaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -30,8 +32,8 @@ class YamlLoaderTest extends BaseLoaderTest
 
     protected function getInputFile($key)
     {
-        $fileRealPath =  __DIR__.'/../../Dumper/yml/'.$key.'.yml';
-        if (!is_file($fileRealPath)) {
+        $fileRealPath =  __DIR__ . '/../../Dumper/yml/' . $key . '.yml';
+        if (! is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('The input file for key "%s" does not exist.', $key));
         }
 

--- a/Tests/Translation/Loader/Symfony/YamlLoaderTest.php
+++ b/Tests/Translation/Loader/Symfony/YamlLoaderTest.php
@@ -30,10 +30,11 @@ class YamlLoaderTest extends BaseLoaderTest
 
     protected function getInputFile($key)
     {
-        if (!is_file($file = __DIR__.'/../../Dumper/yml/'.$key.'.yml')) {
+        $fileRealPath =  __DIR__.'/../../Dumper/yml/'.$key.'.yml';
+        if (!is_file($fileRealPath)) {
             throw new InvalidArgumentException(sprintf('The input file for key "%s" does not exist.', $key));
         }
 
-        return $file;
+        return $fileRealPath;
     }
 }

--- a/Tests/Translation/Loader/SymfonyLoaderAdapterTest.php
+++ b/Tests/Translation/Loader/SymfonyLoaderAdapterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -27,7 +29,7 @@ class SymfonyLoaderAdapterTest extends TestCase
     public function testLoad()
     {
         $symfonyCatalogue = new MessageCatalogue('en');
-        $symfonyCatalogue->add(array('foo' => 'bar'));
+        $symfonyCatalogue->add(['foo' => 'bar']);
 
         $symfonyLoader = $this->createMock('Symfony\Component\Translation\Loader\LoaderInterface');
         $symfonyLoader->expects($this->once())
@@ -35,7 +37,7 @@ class SymfonyLoaderAdapterTest extends TestCase
             ->with('foo', 'en', 'messages')
             ->willReturn($symfonyCatalogue);
 
-        $adapter = new SymfonyLoaderAdapter($symfonyLoader);
+        $adapter         = new SymfonyLoaderAdapter($symfonyLoader);
         $bundleCatalogue = $adapter->load('foo', 'en', 'messages');
         $this->assertInstanceOf('JMS\TranslationBundle\Model\MessageCatalogue', $bundleCatalogue);
         $this->assertEquals('en', $bundleCatalogue->getLocale());

--- a/Tests/Translation/Loader/XliffLoaderTest.php
+++ b/Tests/Translation/Loader/XliffLoaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -31,7 +33,7 @@ class XliffLoaderTest extends TestCase
      */
     public function testLoadIntegration($file)
     {
-        $loader = new XliffLoader();
+        $loader    = new XliffLoader();
         $catalogue = $loader->load($file, 'en');
 
         $dumper = new XliffDumper();
@@ -57,17 +59,17 @@ class XliffLoaderTest extends TestCase
 
         $this->assertEquals(
             $expected,
-            $loader->load(__DIR__.'/Symfony/xliff/old_format.xml', 'en')
+            $loader->load(__DIR__ . '/Symfony/xliff/old_format.xml', 'en')
         );
     }
 
     public function getTestFiles()
     {
-        $files = array();
-        $files[] = array(__DIR__.'/../Dumper/xliff/simple.xml');
-        $files[] = array(__DIR__.'/../Dumper/xliff/structure_with_metadata.xml');
-        $files[] = array(__DIR__.'/../Dumper/xliff/structure.xml');
-        $files[] = array(__DIR__.'/../Dumper/xliff/with_metadata.xml');
+        $files   = [];
+        $files[] = [__DIR__ . '/../Dumper/xliff/simple.xml'];
+        $files[] = [__DIR__ . '/../Dumper/xliff/structure_with_metadata.xml'];
+        $files[] = [__DIR__ . '/../Dumper/xliff/structure.xml'];
+        $files[] = [__DIR__ . '/../Dumper/xliff/with_metadata.xml'];
 
         return $files;
     }

--- a/Tests/Twig/BaseTwigTestCase.php
+++ b/Tests/Twig/BaseTwigTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -18,10 +20,10 @@
 
 namespace JMS\TranslationBundle\Tests\Twig;
 
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Translation\IdentityTranslator;
-use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExtension;
 use JMS\TranslationBundle\Twig\TranslationExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExtension;
+use Symfony\Component\Translation\IdentityTranslator;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\Source;
@@ -30,9 +32,9 @@ abstract class BaseTwigTestCase extends TestCase
 {
     final protected function parse($file, $debug = false)
     {
-        $content = file_get_contents(__DIR__.'/Fixture/'.$file);
+        $content = file_get_contents(__DIR__ . '/Fixture/' . $file);
 
-        $env = new Environment(new ArrayLoader(array()));
+        $env = new Environment(new ArrayLoader([]));
         $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator()));
         $env->addExtension(new TranslationExtension($translator, $debug));
 

--- a/Tests/Twig/DefaultApplyingNodeVisitorTest.php
+++ b/Tests/Twig/DefaultApplyingNodeVisitorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/Tests/Twig/NormalizingNodeVisitorTest.php
+++ b/Tests/Twig/NormalizingNodeVisitorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/Tests/Twig/RemovingNodeVisitorTest.php
+++ b/Tests/Twig/RemovingNodeVisitorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *
@@ -23,7 +25,7 @@ class RemovingNodeVisitorTest extends BaseTwigTestCase
     public function testRemovalWithSimpleTemplate()
     {
         $expected = $this->parse('simple_template_compiled.html.twig');
-        $actual = $this->parse('simple_template.html.twig');
+        $actual   = $this->parse('simple_template.html.twig');
 
         $this->assertEquals($expected, $actual);
     }

--- a/Tests/Twig/TranslationExtensionTest.php
+++ b/Tests/Twig/TranslationExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
  *

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,12 +1,16 @@
 <?php
 
-call_user_func(function () {
-    $autoloadFile = __DIR__.'/../vendor/autoload.php';
+declare(strict_types=1);
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
+call_user_func(static function () {
+    $autoloadFile = __DIR__ . '/../vendor/autoload.php';
     if (! is_file($autoloadFile)) {
-        throw new \LogicException('Could not find vendor/autoload.php. Did you forget to run "composer install --dev"?');
+        throw new LogicException('Could not find vendor/autoload.php. Did you forget to run "composer install --dev"?');
     }
 
     require $autoloadFile;
 
-    \Doctrine\Common\Annotations\AnnotationRegistry::registerLoader('class_exists');
+    AnnotationRegistry::registerLoader('class_exists');
 });

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,7 +1,8 @@
 <?php
 
 call_user_func(function () {
-    if (! is_file($autoloadFile = __DIR__.'/../vendor/autoload.php')) {
+    $autoloadFile = __DIR__.'/../vendor/autoload.php';
+    if (! is_file($autoloadFile)) {
         throw new \LogicException('Could not find vendor/autoload.php. Did you forget to run "composer install --dev"?');
     }
 

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.8",
+        "doctrine/coding-standard": "^7.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "nyholm/nsa": "^1.0.1",
         "phpunit/phpunit": "^8.3",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,6 +18,10 @@
 
     <!-- Include full Doctrine Coding Standard -->
     <rule ref="Doctrine">
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
+
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<ruleset>
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+
+    <!-- Ignore warnings, show progress of the run and show sniff names -->
+    <arg value="nps"/>
+
+    <!-- Directories to be checked -->
+    <file>Tests</file>
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>messages\.en\.php</exclude-pattern>
+    <exclude-pattern>.+\.html\.php$</exclude-pattern>
+    <exclude-pattern>Tests/Translation/Dumper/php/*</exclude-pattern>
+
+    <!-- Include full Doctrine Coding Standard -->
+    <rule ref="Doctrine">
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">
+        <properties>
+            <property
+                name="forbiddenAnnotations"
+                type="array"
+                value="
+                    @api,
+                    @category,
+                    @copyright,
+                    @created,
+                    @license,
+                    @package,
+                    @since,
+                    @subpackage,
+                    @version
+                "
+            />
+        </properties>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="allowFallbackGlobalConstants" type="boolean" value="true"/>
+            <property name="allowFallbackGlobalFunctions" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedGlobalClasses" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedGlobalConstants" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedGlobalFunctions" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedNameForCollidingClasses" type="boolean" value="false"/>
+            <property name="allowFullyQualifiedNameForCollidingConstants" type="boolean" value="false"/>
+            <property name="allowFullyQualifiedNameForCollidingFunctions" type="boolean" value="false"/>
+            <property name="searchAnnotations" type="boolean" value="true"/>
+        </properties>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
+        <properties>
+            <property name="spacesCountBeforeColon" value="0"/>
+        </properties>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="allowFallbackGlobalConstants" type="boolean" value="true"/>
+            <property name="allowFallbackGlobalFunctions" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedGlobalClasses" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedGlobalConstants" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedGlobalFunctions" type="boolean" value="true"/>
+            <property name="allowFullyQualifiedNameForCollidingClasses" type="boolean" value="false"/>
+            <property name="allowFullyQualifiedNameForCollidingConstants" type="boolean" value="false"/>
+            <property name="allowFullyQualifiedNameForCollidingFunctions" type="boolean" value="false"/>
+            <property name="searchAnnotations" type="boolean" value="true"/>
+        </properties>
+    </rule>
+</ruleset>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | Apache2

## Description
I basically copied more or less the structure of Travis and PHPCS from https://github.com/schmittjoh/serializer.

I added `doctrine/coding-standard` package and I also only added `Tests` folder to check the CS. After getting this working, I'll add another PR fixing the rest of the code.

This is going to fail as  it needs to execute `phpcbf` and fix some tests, but that would be after https://github.com/schmittjoh/JMSTranslationBundle/pull/523.

## TODO
- [x] Merge https://github.com/schmittjoh/JMSTranslationBundle/pull/524
- [x] See if https://github.com/schmittjoh/JMSTranslationBundle/pull/526 fix test issues
- [x] Address CS issues