### PR TITLE
Fix calls passing the right scalar type

### DIFF
--- a/Model/Message.php
+++ b/Model/Message.php
@@ -86,7 +86,7 @@ class Message
     {
         $message = new static($id, $domain);
 
-        $trace = debug_backtrace(false);
+        $trace = debug_backtrace(0);
         if (isset($trace[0]['file'])) {
             $message->addSource(new FileSource($trace[0]['file']));
         }

--- a/Tests/Functional/Controller/ApiControllerTest.php
+++ b/Tests/Functional/Controller/ApiControllerTest.php
@@ -13,15 +13,19 @@ class ApiControllerTest extends BaseTestCase
 {
     public function testUpdateAction()
     {
+        // Start application
+        $client = static::createClient([
+            'config' => 'test_updating_translations.yml',
+        ]);
+        $outputDir = $client->getContainer()->getParameter('translation_output_dir');
+
         $isSf4 = version_compare(Kernel::VERSION,'4.0.0') >= 0;
 
         // Add a file
-        $file = $isSf4 ? __DIR__.'/../Fixture/TestBundle/Resources/translations/navigation.en.yaml' : __DIR__.'/../Fixture/TestBundle/Resources/translations/navigation.en.yml';
+        $file = $isSf4 ? $outputDir.'/navigation.en.yaml' : $outputDir.'/navigation.en.yml';
         $written = file_put_contents($file, 'main.home: Home');
         $this->assertTrue($written !== false && $written > 0);
 
-        // Start application
-        $client = static::createClient();
         $client->request('POST', '/_trans/api/configs/app/domains/navigation/locales/en/messages?id=main.home', array('_method'=>'PUT', 'message'=>'Away'));
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
 

--- a/Tests/Functional/config/bundle.yml
+++ b/Tests/Functional/config/bundle.yml
@@ -4,7 +4,7 @@ jms_translation:
             dirs:
                 - "%kernel.project_dir%"
                 - "%kernel.project_dir%/Fixture/TestBundle"
-            output_dir: "%kernel.project_dir%/Fixture/TestBundle/Resources/translations"
+            output_dir: "%translation_output_dir%"
             ignored_domains: [routes]
             excluded_names: ["*TestCase.php", "*Test.php"]
             excluded_dirs: [cache, data, logs]

--- a/Tests/Functional/config/default.yml
+++ b/Tests/Functional/config/default.yml
@@ -3,6 +3,9 @@ imports:
     - { resource: twig.yml }
     - { resource: bundle.yml }
 
+parameters:
+    translation_output_dir: "%kernel.root_dir%/Fixture/TestBundle/Resources/translations"
+
 services:
     logger:
         class: Psr\Log\NullLogger

--- a/Tests/Functional/config/test_updating_translations.yml
+++ b/Tests/Functional/config/test_updating_translations.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: default.yml }
+
+parameters:
+    translation_output_dir: "%kernel.cache_dir%/translations"
+

--- a/Translation/Dumper/XliffDumper.php
+++ b/Translation/Dumper/XliffDumper.php
@@ -108,7 +108,7 @@ class XliffDumper implements DumperInterface
         }
 
         $file->setAttribute('source-language', $this->sourceLanguage);
-        $file->setAttribute('target-language', $catalogue->getLocale());
+        $file->setAttribute('target-language', (string) $catalogue->getLocale());
         $file->setAttribute('datatype', 'plaintext');
         $file->setAttribute('original', 'not.available');
 
@@ -128,7 +128,7 @@ class XliffDumper implements DumperInterface
         foreach ($catalogue->getDomain($domain)->all() as $id => $message) {
             $body->appendChild($unit = $doc->createElement('trans-unit'));
             $unit->setAttribute('id', hash('sha1', $id));
-            $unit->setAttribute('resname', $id);
+            $unit->setAttribute('resname', (string) $id);
             if ($message instanceof XliffMessage && $message->isApproved()) {
                 $unit->setAttribute('approved', 'yes');
             }
@@ -157,9 +157,9 @@ class XliffDumper implements DumperInterface
 
             if ($message instanceof XliffMessage) {
                 if ($message->hasState()) {
-                    $target->setAttribute('state', $message->getState());
+                    $target->setAttribute('state', (string) $message->getState());
                 }
-                
+
                 if ($message->hasNotes()) {
                     foreach ($message->getNotes() as $note) {
                         $noteNode = $unit->appendChild($doc->createElement('note', $note['text']));
@@ -182,11 +182,11 @@ class XliffDumper implements DumperInterface
 
                             if ($this->addReferencePosition) {
                                 if ($source->getLine()) {
-                                    $refFile->setAttribute('line', $source->getLine());
+                                    $refFile->setAttribute('line', (string) $source->getLine());
                                 }
 
                                 if ($source->getColumn()) {
-                                    $refFile->setAttribute('column', $source->getColumn());
+                                    $refFile->setAttribute('column', (string) $source->getColumn());
                                 }
                             }
 

--- a/Translation/Extractor/FileExtractor.php
+++ b/Translation/Extractor/FileExtractor.php
@@ -217,12 +217,12 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
 
                 $this->logger->debug(sprintf('Parsing file "%s"', $file));
 
-                if (false !== $pos = strrpos($file, '.')) {
-                    $extension = substr($file, $pos + 1);
+                if (false !== $pos = strrpos((string) $file, '.')) {
+                    $extension = substr((string) $file, $pos + 1);
 
                     if ('php' === $extension) {
                         try {
-                            $ast = $this->phpParser->parse(file_get_contents($file));
+                            $ast = $this->phpParser->parse(file_get_contents((string) $file));
                         } catch (Error $ex) {
                             throw new \RuntimeException(sprintf('Could not parse "%s": %s', $file, $ex->getMessage()), $ex->getCode(), $ex);
                         }
@@ -231,7 +231,7 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
                         $visitingArgs[] = $ast;
                     } elseif ('twig' === $extension) {
                         $visitingMethod = 'visitTwigFile';
-                        $visitingArgs[] = $this->twig->parse($this->twig->tokenize(new Source(file_get_contents($file), (string) $file)));
+                        $visitingArgs[] = $this->twig->parse($this->twig->tokenize(new Source(file_get_contents((string) $file), (string) $file)));
                     }
                 }
 

--- a/Translation/Updater.php
+++ b/Translation/Updater.php
@@ -156,7 +156,7 @@ class Updater
 
             // delete translation files of other formats
             foreach (Finder::create()->name('/^'.$name.'\.'.$this->config->getLocale().'\.[^\.]+$/')->in($this->config->getTranslationsDir())->depth('< 1')->files() as $file) {
-                if ('.'.$format === substr($file, -1 * strlen('.'.$format))) {
+                if ('.'.$format === substr((string) $file, -1 * strlen('.'.$format))) {
                     continue;
                 }
 

--- a/Util/FileUtils.php
+++ b/Util/FileUtils.php
@@ -43,7 +43,7 @@ abstract class FileUtils
     {
         $files = array();
         foreach (Finder::create()->in($directory)->depth('< 1')->files() as $file) {
-            if (!preg_match('/^([^\.]+)\.([^\.]+)\.([^\.]+)$/', basename($file), $match)) {
+            if (!preg_match('/^([^\.]+)\.([^\.]+)\.([^\.]+)$/', basename((string) $file), $match)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | Apache2


## Description
In order to be able to use `declare(strict_types=1)`, I've changed some functions that require an specific type. The changes are:

- [`debug_backtrace` expects an int](https://www.php.net/manual/en/function.debug-backtrace.php).
- [`DOMElement::setAttribute`](https://www.php.net/manual/en/domelement.setattribute.php) expects a string as second argument.
- Some of the changes are because using [SplFileInfo as string, so I casted it](https://www.php.net/manual/en/splfileinfo.tostring.php).
- `substr`, `basename`, `strrpos` and `file_get_contents` expects a string as first argument.
