### PR TITLE
Allow Translation Contracts

### DIFF
--- a/Tests/Twig/TranslationExtensionTest.php
+++ b/Tests/Twig/TranslationExtensionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\TranslationBundle\Tests\Twig;
+
+use JMS\TranslationBundle\Twig\TranslationExtension;
+use PHPUnit\Framework\TestCase;
+
+final class TranslationExtensionTest extends TestCase
+{
+    public function testInvalidConstruction(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TranslationExtension(new \StdClass());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,8 @@
         "nikic/php-parser": "^1.4 || ^2.0 || ^3.0 || ^4.0",
         "symfony/console": "^3.4 || ^4.3",
         "symfony/framework-bundle": "^3.4.31 || ^4.3",
+        "symfony/translation": "^3.4 || ^4.3",
+        "symfony/translation-contracts": "^1.1 || ^2.0",
         "symfony/validator": "^3.4 || ^4.3",
         "twig/twig": "^1.42.4 || ^2.12.5"
     },
@@ -42,7 +44,6 @@
         "symfony/form": "^3.4 || ^4.3",
         "symfony/security-csrf": "^3.4 || ^4.3",
         "symfony/templating": "^3.4 || ^4.3",
-        "symfony/translation": "^3.4 || ^4.3",
         "symfony/twig-bundle": "^3.4.37 || ^4.3.11"
     },
     "config": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
`symfony/translation` was in the `require-dev` section of the composer.json, but the [`translator` service is used in `services.xml`](https://github.com/schmittjoh/JMSTranslationBundle/blob/master/Resources/config/services.xml#L168), so I moved it to the `required` section and also added `translation-contracts` for Symfony 5.
