### PR TITLE
Remove extending from ContainerAwareCommand

### DIFF
--- a/Resources/config/console.xml
+++ b/Resources/config/console.xml
@@ -7,10 +7,21 @@
     <services>
         <service id="jms_translation.command.extract" class="JMS\TranslationBundle\Command\ExtractTranslationCommand" public="false">
             <tag name="console.command" command="translation:extract" />
+            <argument type="service" id="jms_translation.config_factory"/>
+            <argument type="service" id="jms_translation.updater"/>
+            <argument>%jms_translation.locales%</argument>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
         </service>
 
         <service id="jms_translation.command.list_resources" class="JMS\TranslationBundle\Command\ResourcesListCommand" public="false">
             <tag name="console.command" command="translation:list-resources" />
+            <argument>%kernel.project_dir%</argument>
+            <argument>%kernel.bundles%</argument>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
         </service>
     </services>
 </container>

--- a/Resources/config/console.xml
+++ b/Resources/config/console.xml
@@ -10,18 +10,13 @@
             <argument type="service" id="jms_translation.config_factory"/>
             <argument type="service" id="jms_translation.updater"/>
             <argument>%jms_translation.locales%</argument>
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
         </service>
 
         <service id="jms_translation.command.list_resources" class="JMS\TranslationBundle\Command\ResourcesListCommand" public="false">
             <tag name="console.command" command="translation:list-resources" />
             <argument>%kernel.project_dir%</argument>
             <argument>%kernel.bundles%</argument>
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
+            <argument type="expression">container.hasParameter('kernel.root_dir') ? parameter('kernel.root_dir') : null</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | I guess so
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/schmittjoh/JMSTranslationBundle/pull/515
| License       | Apache2


## Description
I removed extending from `ContainerAwareCommand` by extending from `Command` and adding `getContainer` and `setContainer` methods and also calling `setContainer` from the service declaration. I think it is BC, but maybe I'm missing something.