### PR TITLE
Use array access to twig argument nodes

### DIFF
--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -99,12 +99,12 @@ class TwigFileExtractor extends AbstractNodeVisitor implements FileVisitorInterf
                 }
                 $id = $idNode->getAttribute('value');
 
-                $index = 'trans' === $name ? 1 : 2;
-                $domain = 'messages';
-                $arguments = $node->getNode('arguments');
-                if ($arguments->hasNode($index)) {
-                    $argument = $arguments->getNode($index);
-                    if (!$argument instanceof ConstantExpression) {
+                $index     = $name === 'trans' ? 1 : 2;
+                $domain    = 'messages';
+                $arguments = iterator_to_array($node->getNode('arguments'));
+                if (isset($arguments[$index])) {
+                    $argument = $arguments[$index];
+                    if (! $argument instanceof ConstantExpression) {
                         return $node;
                         // FIXME: Throw exception if there is some way for the user to turn this off
                         //        on a case-by-case basis, similar to @Ignore in PHP
@@ -122,14 +122,14 @@ class TwigFileExtractor extends AbstractNodeVisitor implements FileVisitorInterf
                     }
 
                     $name = $this->stack[$i]->getNode('filter')->getAttribute('value');
-                    if ('desc' === $name || 'meaning' === $name) {
-                        $arguments = $this->stack[$i]->getNode('arguments');
-                        if (!$arguments->hasNode(0)) {
+                    if ($name === 'desc' || $name === 'meaning') {
+                        $arguments = iterator_to_array($this->stack[$i]->getNode('arguments'));
+                        if (! isset($arguments[0])) {
                             throw new RuntimeException(sprintf('The "%s" filter requires exactly one argument, the description text.', $name));
                         }
 
-                        $text = $arguments->getNode(0);
-                        if (!$text instanceof ConstantExpression) {
+                        $text = $arguments[0];
+                        if (! $text instanceof ConstantExpression) {
                             throw new RuntimeException(sprintf('The first argument of the "%s" filter must be a constant expression, such as a string.', $name));
                         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
I was trying to apply CS, but when using `strict_types`, it fails when accessing a `Node::getNode` and `Node::hasNode` with an `integer` value. So instead of that, now it converts the node in array ([seen in SearchAndRenderBlockNode](https://github.com/symfony/symfony/blob/3.4/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php#L31)).