### PR TITLE
Fixed object instead of string error introduced by strict_types

### DIFF
--- a/Translation/Loader/Symfony/XliffLoader.php
+++ b/Translation/Loader/Symfony/XliffLoader.php
@@ -42,7 +42,7 @@ class XliffLoader implements LoaderInterface
     public function load($resource, $locale, $domain = 'messages')
     {
         $previous = libxml_use_internal_errors(true);
-        if (false === $xml = simplexml_load_file($resource)) {
+        if (false === $xml = simplexml_load_file((string)$resource)) {
             libxml_use_internal_errors($previous);
             $error = libxml_get_last_error();
 

--- a/Translation/Loader/Symfony/XliffLoader.php
+++ b/Translation/Loader/Symfony/XliffLoader.php
@@ -42,7 +42,7 @@ class XliffLoader implements LoaderInterface
     public function load($resource, $locale, $domain = 'messages')
     {
         $previous = libxml_use_internal_errors(true);
-        if (false === $xml = simplexml_load_file((string)$resource)) {
+        if (false === $xml = simplexml_load_file((string) $resource)) {
             libxml_use_internal_errors($previous);
             $error = libxml_get_last_error();
 

--- a/Translation/Loader/Symfony/XliffLoader.php
+++ b/Translation/Loader/Symfony/XliffLoader.php
@@ -61,7 +61,7 @@ class XliffLoader implements LoaderInterface
             $catalogue->set($id, (string) $translation->target, $domain);
         }
 
-        $catalogue->addResource(new FileResource($resource));
+        $catalogue->addResource(new FileResource((string) $resource));
 
         return $catalogue;
     }

--- a/Translation/Loader/XliffLoader.php
+++ b/Translation/Loader/XliffLoader.php
@@ -37,7 +37,7 @@ class XliffLoader implements LoaderInterface
     public function load($resource, $locale, $domain = 'messages')
     {
         $previous = libxml_use_internal_errors(true);
-        if (false === $doc = simplexml_load_file($resource)) {
+        if (false === $doc = simplexml_load_file((string)$resource)) {
             libxml_use_internal_errors($previous);
             $libxmlError = libxml_get_last_error();
 

--- a/Translation/Loader/XliffLoader.php
+++ b/Translation/Loader/XliffLoader.php
@@ -37,7 +37,7 @@ class XliffLoader implements LoaderInterface
     public function load($resource, $locale, $domain = 'messages')
     {
         $previous = libxml_use_internal_errors(true);
-        if (false === $doc = simplexml_load_file((string)$resource)) {
+        if (false === $doc = simplexml_load_file((string) $resource)) {
             libxml_use_internal_errors($previous);
             $libxmlError = libxml_get_last_error();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description

When extracting transalations with `--dir` option, following error is thrown
`simplexml_load_file() expects parameter 1 to be a valid path, object given`

This was introduced with adding `strict_types`, as `simplexml_load_file` expects string, but resource object is given. As it have `__toString()` method it explains how it worked before and how to fix this issue rather easly.

## Todos
~- [ ] Tests~
~- [ ] Documentation~
~- [ ] Changelog~
