### PR TITLE
strtolower() expects parameter 1 to be string, object given Issue #544

### DIFF
--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -292,7 +292,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
 
         $var = $node->var;
         while ($var instanceof Node\Expr\MethodCall) {
-            if (!isset($returningMethods[strtolower((string)$var->name)])) {
+            if (!isset($returningMethods[strtolower((string) $var->name)])) {
                 return;
             }
 

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -292,7 +292,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
 
         $var = $node->var;
         while ($var instanceof Node\Expr\MethodCall) {
-            if (!isset($returningMethods[strtolower($var->name)])) {
+            if (!isset($returningMethods[strtolower((string)$var->name)])) {
                 return;
             }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bundle version   | 1.5.4
| Symfony version  | 4.4
| PHP version      | 7.3

### Actual behavior
```
  "exception" => TypeError {
    #message: "strtolower() expects parameter 1 to be string, object given"
    #code: 0
    #file: "./vendor/jms/translation-bundle/Translation/Extractor/File/FormExtractor.php"
    #line: 357
    trace: {
      ./vendor/jms/translation-bundle/Translation/Extractor/File/FormExtractor.php:357 { …}
      ./vendor/jms/translation-bundle/Translation/Extractor/File/FormExtractor.php:111 { …}
      ./vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:123 { …}
      ./vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:146 { …}
```

### Steps to reproduce

Form
```
translation:extract en -vvv
```
