### PR TITLE
Add the option to dump files to the ICU message format

### DIFF
--- a/Command/ExtractTranslationCommand.php
+++ b/Command/ExtractTranslationCommand.php
@@ -82,6 +82,7 @@ class ExtractTranslationCommand extends Command
             ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'The directory where files should be written to.')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'When specified, changes are _NOT_ persisted to disk.')
             ->addOption('output-format', null, InputOption::VALUE_REQUIRED, 'The output format that should be used (in most cases, it is better to change only the default-output-format).')
+            ->addOption('intl-icu', null, InputOption::VALUE_NONE, 'Flag to indicate if translations should be dumped to using the ICU message format.')
             ->addOption('default-output-format', null, InputOption::VALUE_REQUIRED, 'The default output format (defaults to xlf).')
             ->addOption('keep', null, InputOption::VALUE_NONE, 'Define if the updater service should keep the old translation (defaults to false).')
             ->addOption('external-translations-dir', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Load external translation resources');
@@ -177,6 +178,10 @@ class ExtractTranslationCommand extends Command
 
         if ($outputFormat = $input->getOption('output-format')) {
             $builder->setOutputFormat($outputFormat);
+        }
+
+        if ($input->hasParameterOption('intl-icu')) {
+            $builder->setUseIcuMessageFormat(true);
         }
 
         if ($input->getOption('ignore-domain')) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -116,6 +116,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('output_format')->end()
                             ->scalarNode('default_output_format')->end()
+                            ->scalarNode('intl_icu')->defaultValue(false)->end()
                             ->arrayNode('ignored_domains')
                                 ->prototype('scalar')->end()
                             ->end()

--- a/DependencyInjection/JMSTranslationExtension.php
+++ b/DependencyInjection/JMSTranslationExtension.php
@@ -93,6 +93,10 @@ class JMSTranslationExtension extends Extension
                 $def->addMethodCall('setDefaultOutputFormat', [$extractConfig['default_output_format']]);
             }
 
+            if (isset($extractConfig['intl_icu'])) {
+                $def->addMethodCall('setUseIcuMessageFormat', [$extractConfig['intl_icu']]);
+            }
+
             if (isset($extractConfig['keep'])) {
                 $def->addMethodCall('setKeepOldTranslations', [$extractConfig['keep']]);
             }

--- a/Resources/doc/cookbook/config_reference.rst
+++ b/Resources/doc/cookbook/config_reference.rst
@@ -44,6 +44,11 @@ On this page you will find all available configuration options and their meaning
                 # The default output format (defaults to xlf)
                 default_output_format: "xlf"
 
+                # Whether or not to use the ICU message format. This causes
+                # translation files to be suffixed with +intl-icu, e.g.
+                # messages+intl-icu.en.yaml
+                intl_icu: false
+
                 # If true, we will never remove messages from the translation files.
                 # If false, the translation files are up to date with the source.
                 keep: false

--- a/Tests/Util/FileUtilsTest.php
+++ b/Tests/Util/FileUtilsTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\TranslationBundle\Tests\Util;
+
+use JMS\TranslationBundle\Util\FileUtils;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\SplFileInfo;
+
+class FileUtilsTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private $translationDirectory;
+
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem;
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        $this->fileSystem = new Filesystem();
+    }
+
+    public function testAnEmptyDirectoryReturnsNoFiles(): void
+    {
+        $files = FileUtils::findTranslationFiles($this->translationDirectory);
+
+        $this->assertEquals([], $files);
+    }
+
+    public function testNestedDirectoriesAreIgnored(): void
+    {
+        $nestedDirectory = $this->translationDirectory . '/nested';
+        mkdir($nestedDirectory);
+        touch($nestedDirectory . '/messages.en.xliff');
+
+        $files = FileUtils::findTranslationFiles($this->translationDirectory);
+
+        $this->assertEquals([], $files);
+    }
+
+    public function testOnlyTranslationFilesArePickedUp(): void
+    {
+        $this->createTranslationFile('not_a_translation_file.yaml');
+        $this->createTranslationFile('not_a_translation_file.xliff');
+        $this->createTranslationFile('not_a_translation_file.en');
+        $this->createTranslationFile('messages.nl.xliff');
+        $this->createTranslationFile('some-other.en.yaml');
+
+        $files = FileUtils::findTranslationFiles($this->translationDirectory);
+
+        $this->assertCount(2, $files);
+        $this->assertArrayHasKey('messages', $files);
+        $this->assertArrayHasKey('some-other', $files);
+    }
+
+    public function testRegularTranslationFileNamesAreParsed(): void
+    {
+        $this->createTranslationFile('messages.nl.yaml');
+
+        $files = FileUtils::findTranslationFiles($this->translationDirectory);
+
+        $this->assertArrayHasKey('messages', $files);
+        $this->assertArrayHasKey('nl', $files['messages']);
+        $this->assertEquals('yaml', $files['messages']['nl'][0]);
+        $this->assertInstanceOf(SplFileInfo::class, $files['messages']['nl'][1]);
+        $this->assertFalse($files['messages']['nl'][2]);
+    }
+
+    public function testIntlIcuTranslationFileNamesAreParsed(): void
+    {
+        $this->createTranslationFile('messages+intl-icu.en_GB.xliff');
+
+        $files = FileUtils::findTranslationFiles($this->translationDirectory);
+
+        $this->assertArrayHasKey('messages', $files);
+        $this->assertArrayHasKey('en_GB', $files['messages']);
+        $this->assertEquals('xliff', $files['messages']['en_GB'][0]);
+        $this->assertInstanceOf(SplFileInfo::class, $files['messages']['en_GB'][1]);
+        $this->assertTrue($files['messages']['en_GB'][2]);
+    }
+
+    /**
+     * Creates a temporary directory which we can use to run the file utils
+     * tests. It gets cleaned up afterwards.
+     */
+    protected function setUp(): void
+    {
+        $tempDir = sys_get_temp_dir();
+        if (!is_writable($tempDir)) {
+            $this->markTestSkipped(sprintf(
+                "Can't execute FileUtils tests because %s is not writable",
+                $tempDir
+            ));
+        }
+
+        $this->translationDirectory = $tempDir . '/' . uniqid('jms_test_');
+        $directoryCreated = mkdir($this->translationDirectory);
+        if (!$directoryCreated) {
+            $this->markTestSkipped(sprintf(
+                "Can't execute FileUtils tests because %s could not be created",
+                $this->translationDirectory
+            ));
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fileSystem->remove($this->translationDirectory);
+    }
+
+    private function createTranslationFile(string $filename): void
+    {
+        touch($this->translationDirectory . '/' . $filename);
+    }
+}

--- a/Translation/Config.php
+++ b/Translation/Config.php
@@ -63,6 +63,11 @@ final class Config
     private $defaultOutputFormat;
 
     /**
+     * @var bool
+     */
+    private $useIcuMessageFormat;
+
+    /**
      * @var array
      */
     private $scanDirs;
@@ -106,7 +111,7 @@ final class Config
      * @param bool $keepOldMessages
      * @param array $loadResources
      */
-    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources)
+    public function __construct($translationsDir, $locale, array $ignoredDomains, array $domains, $outputFormat, $defaultOutputFormat, $useIcuMessageFormat, array $scanDirs, array $excludedDirs, array $excludedNames, array $enabledExtractors, $keepOldMessages, array $loadResources)
     {
         if (empty($translationsDir)) {
             throw new InvalidArgumentException('The directory where translations are must be set.');
@@ -139,6 +144,7 @@ final class Config
         $this->domains = $domains;
         $this->outputFormat = $outputFormat;
         $this->defaultOutputFormat = $defaultOutputFormat;
+        $this->useIcuMessageFormat = $useIcuMessageFormat;
         $this->locale = $locale;
         $this->scanDirs = $scanDirs;
         $this->excludedDirs = $excludedDirs;
@@ -214,6 +220,14 @@ final class Config
     public function getDefaultOutputFormat()
     {
         return $this->defaultOutputFormat;
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldUseIcuMessageFormat()
+    {
+        return $this->useIcuMessageFormat;
     }
 
     /**

--- a/Translation/ConfigBuilder.php
+++ b/Translation/ConfigBuilder.php
@@ -53,6 +53,11 @@ final class ConfigBuilder
     private $defaultOutputFormat = 'xlf';
 
     /**
+     * @var bool
+     */
+    private $useIcuMessageFormat = false;
+
+    /**
      * @var array
      */
     private $scanDirs = [];
@@ -98,6 +103,7 @@ final class ConfigBuilder
         $builder->setDomains($config->getDomains());
         $builder->setOutputFormat($config->getOutputFormat());
         $builder->setDefaultOutputFormat($config->getDefaultOutputFormat());
+        $builder->setUseIcuMessageFormat($config->shouldUseIcuMessageFormat());
         $builder->setScanDirs($config->getScanDirs());
         $builder->setExcludedDirs($config->getExcludedDirs());
         $builder->setExcludedNames($config->getExcludedNames());
@@ -139,6 +145,23 @@ final class ConfigBuilder
     public function setOutputFormat($format)
     {
         $this->outputFormat = $format;
+
+        return $this;
+    }
+
+    /**
+     * Defines whether or not the ICU message format should be used.
+     *
+     * If enabled, translation files will be suffixed with +intl-icu, e.g.:
+     * message+intl-icu.en.xlf
+     *
+     * @param bool $useIcuMessageFormat
+     *
+     * @return $this
+     */
+    public function setUseIcuMessageFormat($useIcuMessageFormat)
+    {
+        $this->useIcuMessageFormat = $useIcuMessageFormat;
 
         return $this;
     }
@@ -316,6 +339,7 @@ final class ConfigBuilder
             $this->domains,
             $this->outputFormat,
             $this->defaultOutputFormat,
+            $this->useIcuMessageFormat,
             $this->scanDirs,
             $this->excludedDirs,
             $this->excludedNames,

--- a/Translation/Updater.php
+++ b/Translation/Updater.php
@@ -148,7 +148,13 @@ class Updater
             $format = $this->detectOutputFormat($name);
 
             // delete translation files of other formats
-            foreach (Finder::create()->name('/^' . $name . '\.' . $this->config->getLocale() . '\.[^\.]+$/')->in($this->config->getTranslationsDir())->depth('< 1')->files() as $file) {
+            $translationFileRegex = sprintf(
+                '/^%s%s\.%s\.[^\.]+$/',
+                $name,
+                $this->config->shouldUseIcuMessageFormat() ? '+intl-icu' : '',
+                $this->config->getLocale()
+            );
+            foreach (Finder::create()->name($translationFileRegex)->in($this->config->getTranslationsDir())->depth('< 1')->files() as $file) {
                 if ('.' . $format === substr((string) $file, -1 * strlen('.' . $format))) {
                     continue;
                 }
@@ -160,7 +166,14 @@ class Updater
                 }
             }
 
-            $outputFile = $this->config->getTranslationsDir() . '/' . $name . '.' . $this->config->getLocale() . '.' . $format;
+            $outputFile = sprintf(
+                '%s/%s%s.%s.%s',
+                $this->config->getTranslationsDir(),
+                $name,
+                $this->config->shouldUseIcuMessageFormat() ? '+intl-icu' : '',
+                $this->config->getLocale(),
+                $format
+            );
             $this->logger->info(sprintf('Writing translation file "%s".', $outputFile));
             $this->writer->write($this->scannedCatalogue, $name, $outputFile, $format);
         }

--- a/Util/FileUtils.php
+++ b/Util/FileUtils.php
@@ -45,13 +45,19 @@ abstract class FileUtils
     {
         $files = [];
         foreach (Finder::create()->in($directory)->depth('< 1')->files() as $file) {
-            if (!preg_match('/^([^\.]+)\.([^\.]+)\.([^\.]+)$/', basename((string) $file), $match)) {
+            $isTranslationFile = preg_match(
+                '/^(?P<domain>[^\.]+?)(?P<icu>\+intl-icu)?\.(?P<locale>[^\.]+)\.(?P<format>[^\.]+)$/',
+                basename((string) $file),
+                $match
+            );
+            if (!$isTranslationFile) {
                 continue;
             }
 
-            $files[$match[1]][$match[2]] = [
-                $match[3],
+            $files[$match['domain']][$match['locale']] = [
+                $match['format'],
                 $file,
+                !empty($match['icu']),
             ];
         }
 

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "symfony/browser-kit": "^3.4 || ^4.3 || ^5.0",
         "symfony/css-selector": "^3.4 || ^4.3 || ^5.0",
         "symfony/expression-language": "^3.4 || ^4.3 || ^5.0",
+        "symfony/filesystem": "^5.1",
         "symfony/form": "^3.4 || ^4.3 || ^5.0",
         "symfony/security-csrf": "^3.4 || ^4.3 || ^5.0",
         "symfony/templating": "^3.4 || ^4.3 || ^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #550
| License       | Apache2


## Description
As mentioned in #550: this commit adds the options to dump files in the ICU message format. This means the file gets suffixed with `+intl-icu`, e.g.: `messages+intl-icu.en.yaml`.

Some general remarks:

- The new options is called "intl-icu" (`--intl-icu` commandline, `intl_icu` in the config)
- The built-in translation interface works in normal situations, but behaviour is undefined you happen to use e.g. `messages.nl.xliff` as well as `messages+intl-icu.nl.xliff`. There is no indication which file you're editing, and no option to switch. It still works though, so I see this more as a thing for a future PR.
- As you can see in `FileUtils`: I took the liberty to use named capturing groups, because with another group added things were getting confusing.
- The classes I touched don't seem to have any relevant tests. I intend to add a test for `FileUtils`, but wanted to get this PR out first in order to get some feedback.
- I (manually) tested in a dummy project, but I intend to try this branch in a real-world project as well, either tomorrow or somewhere next week.

So, happy to hear your feedback!
