### PR TITLE
Prevent all non message Form Constraint option from being extracted

### DIFF
--- a/Tests/Translation/Extractor/File/Fixture/MyFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormType.php
@@ -46,6 +46,7 @@ class MyFormType extends AbstractType
                 'translation_domain' => 'address',
                 'constraints' => [
                     new NotBlank(['message' => /** @Desc("You should fill in the street") */ 'form.street.empty_value']),
+                    new Length(['max' => 100]), // https://github.com/schmittjoh/JMSTranslationBundle/issues/553
                 ],
             ])
             ->add('zip', 'text', [

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -110,7 +110,7 @@ class FormExtractorTest extends BasePhpFileExtractorTest
 
         $message = new Message('form.label.zip', 'address');
         $message->setDesc('ZIP');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 53));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 54));
         $expected->add($message);
 
         $message = new Message('form.error.password_mismatch', 'validators');
@@ -119,33 +119,33 @@ class FormExtractorTest extends BasePhpFileExtractorTest
         $expected->add($message);
 
         $message = new Message('form.label.created');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 64));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 65));
         $expected->add($message);
 
         $message = new Message('field.with.placeholder');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 57));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 58));
         $expected->add($message);
 
         $message = new Message('form.placeholder.text');
         $message->setDesc('Field with a placeholder value');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 58));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 59));
         $expected->add($message);
 
         $message = new Message('form.placeholder.text.but.no.label');
         $message->setDesc('Field with a placeholder but no label');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 62));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 63));
         $expected->add($message);
 
         $message = new Message('form.dueDate.empty.year');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 66));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 67));
         $expected->add($message);
 
         $message = new Message('form.dueDate.empty.month');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 66));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 67));
         $expected->add($message);
 
         $message = new Message('form.dueDate.empty.day');
-        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 66));
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 67));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('MyFormType.php'));

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -313,6 +313,9 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
                 if (!$messageItem->key instanceof Node\Scalar\String_) {
                     continue;
                 }
+                if (strtolower(substr($messageItem->key->value, -7)) !== 'message') {
+                    continue;
+                }
                 $this->parseItem($messageItem, $domain);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #553 
| License       | Apache2


## Description
The goal of this PR is to filter Form Constraint options to extract.
Some of these options are values and are not meant to be extracted.

I assumed that only the option ending with the string `message` should be extracted because this pattern seems pretty correct for all predefined Constraints, plus it keeps extracting options of custom constraints ending with 'message'.

Example
```php
new Assert\Length([
    'min' => 5,
    'max' => 50,
    'minMessage' => 'length.min.message',
    'maxMessage' => 'length.max.message',
]),
new Assert\Regex([
    'pattern' => '/,/',
    'match' => false,
    'message' => 'regex.message',
]),
```

Only those three keys should be extracted :
- 'length.min.message'
- 'length.max.message'
- 'regex.message'

Currently the number 5, the number 50 and the pattern string are extracted too.

Please tell me if the way I filter those options need to be improved.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog
