### PR TITLE
Remove translation file if all translations removed

### DIFF
--- a/Translation/Updater.php
+++ b/Translation/Updater.php
@@ -177,6 +177,20 @@ class Updater
             $this->logger->info(sprintf('Writing translation file "%s".', $outputFile));
             $this->writer->write($this->scannedCatalogue, $name, $outputFile, $format);
         }
+        // Remove file if all translations removed
+        $endOfFile = sprintf('.%s.%s', $this->config->getLocale(), $format);
+        $translationFilesRegex = sprintf('/%s$/', $endOfFile);
+        foreach(Finder::create()->name($translationFilesRegex)->in($this->config->getTranslationsDir())->files() as $file){
+            $domainName = str_replace($endOfFile, '', $file->getFilename());
+            if($this->scannedCatalogue->hasDomain($domainName)){
+                continue;
+            }
+
+            $this->logger->info(sprintf('Deleting translation file "%s".', $file));
+            if (false === @unlink((string) $file)) {
+                throw new RuntimeException(sprintf('Could not delete the translation file "%s".', $file));
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
I added a part to delete all files that not exist in the generated domains anymore

scenario to reproduce
- add new translation for new domain
- dump translations (new domain created)
- delete the translation
- dump again

ER: the file deleted as domain not exist anymore
AR: the file exist

## Todos
- [ x ] Tests
- [ ] Documentation
- [ ] Changelog
