### PR TITLE
Fix --intl-icu option

### DIFF
--- a/Command/ExtractTranslationCommand.php
+++ b/Command/ExtractTranslationCommand.php
@@ -180,7 +180,7 @@ class ExtractTranslationCommand extends Command
             $builder->setOutputFormat($outputFormat);
         }
 
-        if ($input->hasParameterOption('intl-icu')) {
+        if ($input->hasParameterOption('--intl-icu')) {
             $builder->setUseIcuMessageFormat(true);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | N/A
| License       | Apache2


## Description
`--intl-icu` option was never interpreted because of a misuse of `InputInterface::hasParameterOption`. ICU message format couldn't be used. 

There could be a BC break for users who have leave an `--intl-icu` option while using a workaround like a domain name directly suffixed with `+intl-icu`.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
