### PR TITLE
Fallback to 'messages' domain when domain is null in trans|transchoice methods

### DIFF
--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -162,7 +162,11 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
 
         $index = $this->methodsToExtractFrom[strtolower($methodCallNodeName)];
         if (isset($node->args[$index])) {
-            if (!$node->args[$index]->value instanceof String_) {
+            if ($node->args[$index]->value instanceof Node\Expr\ConstFetch && 'null' === (string) $node->args[$index]->value->name) {
+                $domain = 'messages';
+            } elseif ($node->args[$index]->value instanceof String_) {
+                $domain = $node->args[$index]->value->value;
+            } else {
                 if ($ignore) {
                     return;
                 }
@@ -177,8 +181,6 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
 
                 throw new RuntimeException($message);
             }
-
-            $domain = $node->args[$index]->value->value;
         } else {
             $domain = 'messages';
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | Apache2


## Description
Currently when calling `trans` or `transchoice` and passing a domain argument set to null, it emits a warnings during the extraction.

```
Can only extract the translation domain from a scalar string, but got "PhpParser\Node\Expr\ConstFetch". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in xxx.php on line xx).
```

With this PR, it will instead fallback to the default domain `messages`.
