### PR TITLE
Support named argument for domain extraction

### DIFF
--- a/Translation/Extractor/File/DefaultPhpFileExtractor.php
+++ b/Translation/Extractor/File/DefaultPhpFileExtractor.php
@@ -159,19 +159,36 @@ class DefaultPhpFileExtractor implements LoggerAwareInterface, FileVisitorInterf
         }
 
         $id = $node->args[0]->value->value;
-
         $index = $this->methodsToExtractFrom[strtolower($methodCallNodeName)];
-        if (isset($node->args[$index])) {
-            if ($node->args[$index]->value instanceof Node\Expr\ConstFetch && 'null' === (string) $node->args[$index]->value->name) {
+        $domainArg = null;
+
+        if (isset($node->args[$index]) && $node->args[$index] instanceof Node\Arg && null === $node->args[$index]->name ) {
+            $domainArg = $node->args[$index];
+        } else {
+            foreach ($node->args as $arg) {
+                if (!$arg instanceof Node\Arg) {
+                    continue;
+                }
+
+                if (null !== $arg->name && 'domain' === $arg->name->name) {
+                    $domainArg = $arg;
+
+                    break;
+                }
+            }
+        }
+
+        if (null !== $domainArg) {
+            if ($domainArg->value instanceof Node\Expr\ConstFetch && 'null' === (string) $domainArg->value->name) {
                 $domain = 'messages';
-            } elseif ($node->args[$index]->value instanceof String_) {
-                $domain = $node->args[$index]->value->value;
+            } elseif ($domainArg->value instanceof String_) {
+                $domain = $domainArg->value->value;
             } else {
                 if ($ignore) {
                     return;
                 }
 
-                $message = sprintf('Can only extract the translation domain from a scalar string, but got "%s". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[$index]->value), $this->file, $node->args[$index]->value->getLine());
+                $message = sprintf('Can only extract the translation domain from a scalar string, but got "%s". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($domainArg->value), $this->file, $domainArg->value->getLine());
 
                 if ($this->logger) {
                     $this->logger->error($message);

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "nikic/php-parser": "^1.4 || ^2.0 || ^3.0 || ^4.0",
+        "nikic/php-parser": "^4.9",
         "symfony/console": "^3.4 || ^4.3 || ^5.0",
         "symfony/expression-language": "^3.4 || ^4.3 || ^5.0",
         "symfony/framework-bundle": "^3.4.31 || ^4.3 || ^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | Apache2


## Description
Currently when calling `trans` and passing a named argument for domain to avoid passing other optional arguments, it isn't extracted properly.


With this PR, passing the domain as named argument will be supported.