### PR TITLE
Allow to use translate controller without sensio/framework-extra-bundle

### DIFF
--- a/Controller/TranslateController.php
+++ b/Controller/TranslateController.php
@@ -26,7 +26,9 @@ use JMS\TranslationBundle\Translation\LoaderManager;
 use JMS\TranslationBundle\Util\FileUtils;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Twig\Environment;
 
 /**
  * Translate Controller.
@@ -46,14 +48,20 @@ class TranslateController
     private $loader;
 
     /**
+     * @var Environment|null
+     */
+    private $twig;
+
+    /**
      * @var string
      */
     private $sourceLanguage;
 
-    public function __construct(ConfigFactory $configFactory, LoaderManager $loader)
+    public function __construct(ConfigFactory $configFactory, LoaderManager $loader, ?Environment $twig = null)
     {
         $this->configFactory = $configFactory;
         $this->loader = $loader;
+        $this->twig = $twig;
     }
 
     /**
@@ -67,7 +75,7 @@ class TranslateController
     /**
      * @param Request $request
      *
-     * @return array
+     * @return Response|array
      *
      * @Route("/", name="jms_translation_index", options = {"i18n" = false})
      * @Template("@JMSTranslation/Translate/index.html.twig")
@@ -136,7 +144,7 @@ class TranslateController
             $existingMessages[$id] = $message;
         }
 
-        return [
+        $variables = [
             'selectedConfig' => $config,
             'configs' => $configs,
             'selectedDomain' => $domain,
@@ -151,5 +159,11 @@ class TranslateController
             'file' => (string) $files[$domain][$locale][1],
             'sourceLanguage' => $this->sourceLanguage,
         ];
+
+        if (null !== $this->twig) {
+            return new Response($this->twig->render('@JMSTranslation/Translate/index.html.twig', $variables));
+        }
+
+        return $variables;
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -41,6 +41,7 @@
         <service id="jms_translation.controller.translate_controller" class="%jms_translation.controller.translate_controller.class%" public="true">
             <argument type="service" id="jms_translation.config_factory"/>
             <argument type="service" id="jms_translation.loader_manager"/>
+            <argument type="service" id="twig"/>
             <call method="setSourceLanguage">
                 <argument>%jms_translation.source_language%</argument>
             </call>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   |
| Fixed tickets | 
| License       | Apache2


## Description
Allow to use the translate controller without the `sensio/framework-extra-bundle` package.
