### PR TITLE
resolved deprecation notice with Symfony 5.4

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -33,7 +33,7 @@ class Configuration implements ConfigurationInterface
         $this->container = $container;
     }
 
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $c = $this->container;
 


### PR DESCRIPTION
PR resolves this deprecation:

Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "JMS\TranslationBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2

