### PR TITLE
Fix #575: Remove deprecation notices with string interpolation

### DIFF
--- a/DependencyInjection/JMSTranslationExtension.php
+++ b/DependencyInjection/JMSTranslationExtension.php
@@ -41,7 +41,7 @@ class JMSTranslationExtension extends Extension
         $container->setParameter('jms_translation.locales', $config['locales']);
 
         foreach ($config['dumper'] as $option => $value) {
-            $container->setParameter("jms_translation.dumper.${option}", $value);
+            $container->setParameter("jms_translation.dumper.$option", $value);
         }
 
         $requests = [];

--- a/Tests/Twig/RemovingNodeVisitorTest.php
+++ b/Tests/Twig/RemovingNodeVisitorTest.php
@@ -30,8 +30,8 @@ class RemovingNodeVisitorTest extends BaseTwigTestCase
 
         $templateSuffix = $isSF5 ? '_sf5' : '';
 
-        $expected = $this->parse("simple_template_compiled${templateSuffix}.html.twig");
-        $actual   = $this->parse("simple_template${templateSuffix}.html.twig");
+        $expected = $this->parse("simple_template_compiled$templateSuffix.html.twig");
+        $actual   = $this->parse("simple_template$templateSuffix.html.twig");
 
         $this->assertEquals($expected, $actual);
     }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #575
| License       | Apache2


## Description
Remove new deprecation notices with PHP 8.2.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
