### PR TITLE
Add void return signatures to remove deprecation notices

### DIFF
--- a/Command/ExtractTranslationCommand.php
+++ b/Command/ExtractTranslationCommand.php
@@ -64,7 +64,7 @@ class ExtractTranslationCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('jms:translation:extract')

--- a/Command/ResourcesListCommand.php
+++ b/Command/ResourcesListCommand.php
@@ -59,7 +59,7 @@ class ResourcesListCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('jms:translation:list-resources')

--- a/DependencyInjection/Compiler/IntegrationPass.php
+++ b/DependencyInjection/Compiler/IntegrationPass.php
@@ -25,7 +25,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class IntegrationPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('translation.loader.xliff')) {
             return;

--- a/DependencyInjection/Compiler/MountDumpersPass.php
+++ b/DependencyInjection/Compiler/MountDumpersPass.php
@@ -28,7 +28,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class MountDumpersPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('jms_translation.file_writer')) {
             return;

--- a/DependencyInjection/Compiler/MountExtractorsPass.php
+++ b/DependencyInjection/Compiler/MountExtractorsPass.php
@@ -27,7 +27,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class MountExtractorsPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('jms_translation.extractor_manager')) {
             return;

--- a/DependencyInjection/Compiler/MountFileVisitorsPass.php
+++ b/DependencyInjection/Compiler/MountFileVisitorsPass.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class MountFileVisitorsPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('jms_translation.extractor.file_extractor')) {
             return;

--- a/DependencyInjection/Compiler/MountLoadersPass.php
+++ b/DependencyInjection/Compiler/MountLoadersPass.php
@@ -28,7 +28,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class MountLoadersPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('jms_translation.loader_manager')) {
             return;

--- a/DependencyInjection/JMSTranslationExtension.php
+++ b/DependencyInjection/JMSTranslationExtension.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class JMSTranslationExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration(new Configuration($container), $configs);
 

--- a/JMSTranslationBundle.php
+++ b/JMSTranslationBundle.php
@@ -30,7 +30,7 @@ class JMSTranslationBundle extends Bundle
 {
     const VERSION = '1.1.0-DEV';
 
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new IntegrationPass());
         $container->addCompilerPass(new MountFileVisitorsPass());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
This PR gets rid of the following deprecation notices:

Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "JMS\TranslationBundle\DependencyInjection\JMSTranslationExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "JMS\TranslationBundle\DependencyInjection\Compiler\IntegrationPass" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "JMS\TranslationBundle\DependencyInjection\Compiler\MountFileVisitorsPass" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "JMS\TranslationBundle\DependencyInjection\Compiler\MountExtractorsPass" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "JMS\TranslationBundle\DependencyInjection\Compiler\MountLoadersPass" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "JMS\TranslationBundle\DependencyInjection\Compiler\MountDumpersPass" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "JMS\TranslationBundle\Command\ExtractTranslationCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "JMS\TranslationBundle\Command\ResourcesListCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "JMS\TranslationBundle\JMSTranslationBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
php

