### PR TITLE
fix: prevent type error on choices array with optional keys

### DIFF
--- a/Tests/Translation/Extractor/File/Fixture/MyFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormType.php
@@ -67,4 +67,6 @@ class MyFormType extends AbstractType
             'empty_value' => ['year' => 'form.dueDate.empty.year', 'month' => 'form.dueDate.empty.month', 'day' => 'form.dueDate.empty.day'],
         ]);
     }
+
+    const CHOICES = ['choices' => [null]];
 }

--- a/Tests/Translation/Extractor/File/Fixture/MyFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyFormType.php
@@ -68,5 +68,5 @@ class MyFormType extends AbstractType
         ]);
     }
 
-    const CHOICES = ['choices' => [null]];
+    public const CHOICES = ['choices' => [null]];
 }

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -148,6 +148,10 @@ class FormExtractorTest extends BasePhpFileExtractorTest
         $message->addSource($fileSourceFactory->create($fixtureSplInfo, 67));
         $expected->add($message);
 
+        $message = new Message(0);
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, -1));
+        $expected->add($message);
+
         $this->assertEquals($expected, $this->extract('MyFormType.php'));
     }
 

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -241,10 +241,10 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
             return true;
         }
 
-        foreach ($item->value->items as $subItem) {
+        foreach ($item->value->items as $index => $subItem) {
             $newItem = clone $subItem;
             $newItem->key = $subItem->value;
-            $newItem->value = $subItem->key;
+            $newItem->value = $subItem->key ?? new Node\Scalar\Int_($index);
             $subItem = $newItem;
             $this->parseItem($subItem, $domain);
         }

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -244,7 +244,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
         foreach ($item->value->items as $index => $subItem) {
             $newItem = clone $subItem;
             $newItem->key = $subItem->value;
-            $newItem->value = $subItem->key ?? new Node\Scalar\Int_($index);
+            $newItem->value = $subItem->key ?? new Node\Scalar\LNumber($index);
             $subItem = $newItem;
             $this->parseItem($subItem, $domain);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
`TypeError: Cannot assign null to property PhpParser\Node\ArrayItem::$value of type PhpParser\Node\Expr`
