### PR TITLE
Removed usage of deprecated AbstractNodeVisitor

### DIFF
--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -31,9 +31,9 @@ use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FilterExpression;
 use Twig\Node\Node;
 use Twig\NodeTraverser;
-use Twig\NodeVisitor\AbstractNodeVisitor;
+use Twig\NodeVisitor\NodeVisitorInterface;
 
-class TwigFileExtractor extends AbstractNodeVisitor implements FileVisitorInterface
+class TwigFileExtractor implements FileVisitorInterface, NodeVisitorInterface
 {
     /**
      * @var FileSourceFactory
@@ -66,10 +66,7 @@ class TwigFileExtractor extends AbstractNodeVisitor implements FileVisitorInterf
         $this->traverser = new NodeTraverser($env, [$this]);
     }
 
-    /**
-     * @return Node
-     */
-    protected function doEnterNode(Node $node, Environment $env)
+    public function enterNode(Node $node, Environment $env): Node
     {
         $this->stack[] = $node;
 
@@ -145,10 +142,7 @@ class TwigFileExtractor extends AbstractNodeVisitor implements FileVisitorInterf
         return $node;
     }
 
-    /**
-     * @return int
-     */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 0;
     }
@@ -178,10 +172,7 @@ class TwigFileExtractor extends AbstractNodeVisitor implements FileVisitorInterf
         }
     }
 
-    /**
-     * @return Node
-     */
-    protected function doLeaveNode(Node $node, Environment $env)
+    public function leaveNode(Node $node, Environment $env): Node
     {
         array_pop($this->stack);
 

--- a/Twig/DefaultApplyingNodeVisitor.php
+++ b/Twig/DefaultApplyingNodeVisitor.php
@@ -29,7 +29,7 @@ use Twig\Node\Expression\ConditionalExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FilterExpression;
 use Twig\Node\Node;
-use Twig\NodeVisitor\AbstractNodeVisitor;
+use Twig\NodeVisitor\NodeVisitorInterface;
 
 /**
  * Applies the value of the "desc" filter if the "trans" filter has no
@@ -39,7 +39,7 @@ use Twig\NodeVisitor\AbstractNodeVisitor;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
+class DefaultApplyingNodeVisitor implements NodeVisitorInterface
 {
     /**
      * @var bool
@@ -51,10 +51,7 @@ class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
         $this->enabled = (bool) $bool;
     }
 
-    /**
-     * @return Node
-     */
-    public function doEnterNode(Node $node, Environment $env)
+    public function enterNode(Node $node, Environment $env): Node
     {
         if (!$this->enabled) {
             return $node;
@@ -133,18 +130,12 @@ class DefaultApplyingNodeVisitor extends AbstractNodeVisitor
         return $node;
     }
 
-    /**
-     * @return Node
-     */
-    public function doLeaveNode(Node $node, Environment $env)
+    public function leaveNode(Node $node, Environment $env): Node
     {
         return $node;
     }
 
-    /**
-     * @return int
-     */
-    public function getPriority()
+    public function getPriority(): int
     {
         return -2;
     }

--- a/Twig/NormalizingNodeVisitor.php
+++ b/Twig/NormalizingNodeVisitor.php
@@ -24,7 +24,7 @@ use Twig\Environment;
 use Twig\Node\Expression\Binary\ConcatBinary;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Node;
-use Twig\NodeVisitor\AbstractNodeVisitor;
+use Twig\NodeVisitor\NodeVisitorInterface;
 
 /**
  * Performs equivalence transformations on the AST to ensure that
@@ -34,20 +34,14 @@ use Twig\NodeVisitor\AbstractNodeVisitor;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class NormalizingNodeVisitor extends AbstractNodeVisitor
+class NormalizingNodeVisitor implements NodeVisitorInterface
 {
-    /**
-     * @return Node
-     */
-    protected function doEnterNode(Node $node, Environment $env)
+    public function enterNode(Node $node, Environment $env): Node
     {
         return $node;
     }
 
-    /**
-     * @return ConstantExpression|Node
-     */
-    protected function doLeaveNode(Node $node, Environment $env)
+    public function leaveNode(Node $node, Environment $env): Node
     {
         if (
             $node instanceof ConcatBinary
@@ -60,10 +54,7 @@ class NormalizingNodeVisitor extends AbstractNodeVisitor
         return $node;
     }
 
-    /**
-     * @return int
-     */
-    public function getPriority()
+    public function getPriority(): int
     {
         return -3;
     }

--- a/Twig/RemovingNodeVisitor.php
+++ b/Twig/RemovingNodeVisitor.php
@@ -23,14 +23,14 @@ namespace JMS\TranslationBundle\Twig;
 use Twig\Environment;
 use Twig\Node\Expression\FilterExpression;
 use Twig\Node\Node;
-use Twig\NodeVisitor\AbstractNodeVisitor;
+use Twig\NodeVisitor\NodeVisitorInterface;
 
 /**
  * Removes translation metadata filters from the AST.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class RemovingNodeVisitor extends AbstractNodeVisitor
+class RemovingNodeVisitor implements NodeVisitorInterface
 {
     /**
      * @var bool
@@ -42,10 +42,7 @@ class RemovingNodeVisitor extends AbstractNodeVisitor
         $this->enabled = (bool) $bool;
     }
 
-    /**
-     * @return Node
-     */
-    protected function doEnterNode(Node $node, Environment $env)
+    public function enterNode(Node $node, Environment $env): Node
     {
         if ($this->enabled && $node instanceof FilterExpression) {
             $name = $node->getNode('filter')->getAttribute('value');
@@ -58,18 +55,12 @@ class RemovingNodeVisitor extends AbstractNodeVisitor
         return $node;
     }
 
-    /**
-     * @return Node
-     */
-    protected function doLeaveNode(Node $node, Environment $env)
+    public function leaveNode(Node $node, Environment $env): Node
     {
         return $node;
     }
 
-    /**
-     * @return int
-     */
-    public function getPriority()
+    public function getPriority(): int
     {
         return -1;
     }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/translation": "^4.3 || ^5.4 || ^6.0",
         "symfony/translation-contracts": "^1.1 || ^2.0 || ^3.0",
         "symfony/validator": "^4.3 || ^5.4 || ^6.0",
-        "twig/twig": "^1.42.4 || ^2.12.5 || ^3.0",
+        "twig/twig": "^2.13.1 || ^3.0",
         "psr/log": "^1.0 || ^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
Using `Twig\NodeVisitor\AbstractNodeVisitor` is deprecated. This PR removes the usage of the `AbstractNodeVisitor` class and replaces it with implementing the `NodeVisitorInterface`. 
The support for Twig v1.X was dropped to do it safely. 

## Todos
- [x] Tests - not necessary to add new tests
- [x] Documentation - unchanged
- [ ] Changelog
