### PR TITLE
Fix named parameter used for `trans` filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - "master"
+      - "1.x"
 
 jobs:
   phpunit:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           - "highest"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
         with:
           fetch-depth: 2
 
@@ -47,7 +47,7 @@ jobs:
           args: extra.symfony.require ${{ matrix.symfony-version }}
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "${{ matrix.composer-options }}"

--- a/Tests/Translation/Extractor/File/Fixture/simple_template.html.twig
+++ b/Tests/Translation/Extractor/File/Fixture/simple_template.html.twig
@@ -19,3 +19,5 @@
 {{ "foo.bar4" | transchoice(5, {'%name%': 'Johannes'}, 'app') }}
 
 {% trans %}text.default_domain{% endtrans %}
+
+{{ "foo.bar5"|trans(domain='app') }}

--- a/Tests/Translation/Extractor/File/Fixture/simple_template_sf5.html.twig
+++ b/Tests/Translation/Extractor/File/Fixture/simple_template_sf5.html.twig
@@ -17,3 +17,5 @@
 {{ "foo.bar4" | trans({'%count%': 5, '%name%': 'Johannes'}, 'app') }}
 
 {% trans %}text.default_domain{% endtrans %}
+
+{{ "foo.bar5"|trans(domain='app') }}

--- a/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TwigFileExtractorTest.php
@@ -99,6 +99,10 @@ class TwigFileExtractorTest extends TestCase
         $message->addSource($fileSourceFactory->create($fixtureSplInfo, 19));
         $expected->add($message);
 
+        $message = new Message('foo.bar5', 'app');
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 21));
+        $expected->add($message);
+
         $this->assertEquals($expected, $this->extract('simple_template_sf5.html.twig'));
     }
 
@@ -160,6 +164,10 @@ class TwigFileExtractorTest extends TestCase
 
         $message = new Message('text.default_domain');
         $message->addSource($fileSourceFactory->create($fixtureSplInfo, 21));
+        $expected->add($message);
+
+        $message = new Message('foo.bar5', 'app');
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 23));
         $expected->add($message);
 
         $this->assertEquals($expected, $this->extract('simple_template.html.twig'));

--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -27,6 +27,7 @@ use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use JMS\TranslationBundle\Translation\FileSourceFactory;
 use Symfony\Bridge\Twig\Node\TransNode;
 use Twig\Environment;
+use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FilterExpression;
 use Twig\Node\Node;
@@ -97,11 +98,11 @@ class TwigFileExtractor extends AbstractNodeVisitor implements FileVisitorInterf
                 }
                 $id = $idNode->getAttribute('value');
 
-                $index     = $name === 'trans' ? 1 : 2;
                 $domain    = 'messages';
                 $arguments = iterator_to_array($node->getNode('arguments'));
-                if (isset($arguments[$index])) {
-                    $argument = $arguments[$index];
+
+                $argument = $this->findDomainArgument($arguments, $name);
+                if (null !== $argument) {
                     if (! $argument instanceof ConstantExpression) {
                         return $node;
 
@@ -143,6 +144,20 @@ class TwigFileExtractor extends AbstractNodeVisitor implements FileVisitorInterf
         }
 
         return $node;
+    }
+
+    private function findDomainArgument(array $arguments, string $name): ?AbstractExpression
+    {
+        if (isset($arguments['domain'])) {
+            return $arguments['domain'];
+        }
+
+        $index = $name === 'trans' ? 1 : 2;
+        if (isset($arguments[$index])) {
+            return $arguments[$index];
+        }
+
+        return null;
     }
 
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,11 @@
         </testsuite>
     </testsuites>
 
+    <php>
+        <env name="SYMFONY_PHPUNIT_REQUIRE" value="nikic/php-parser:^4.9" />
+        <env name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
+    </php>
+
     <filter>
         <whitelist>
             <directory>./</directory>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | Apache2


## Description
This PR allows `TwigExtractor` to recognize a following case:
```twig
{{ 'Some text that belongs to another translation domain'|trans(domain='not_messages_domain') }}
```

I'd love to have this in 1.x series (since I still have projects that depend on them), but I don't know if it's still under maintenance.

Could you point me to relevant tests to add a case for them?

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
