### PR TITLE
Fix deprecations triggered since twig 3.12.0

### DIFF
--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -82,7 +82,7 @@ class TwigFileExtractor implements FileVisitorInterface, NodeVisitorInterface
             $message->addSource($this->fileSourceFactory->create($this->file, $node->getTemplateLine()));
             $this->catalogue->add($message);
         } elseif ($node instanceof FilterExpression) {
-            $name = $node->getNode('filter')->getAttribute('value');
+            $name = $node->hasAttribute('name') ? $node->getAttribute('name') : $node->getNode('filter')->getAttribute('value');
 
             if ('trans' === $name || 'transchoice' === $name) {
                 $idNode = $node->getNode('node');
@@ -117,7 +117,7 @@ class TwigFileExtractor implements FileVisitorInterface, NodeVisitorInterface
                         break;
                     }
 
-                    $name = $this->stack[$i]->getNode('filter')->getAttribute('value');
+                    $name = $this->stack[$i]->hasAttribute('name') ? $this->stack[$i]->getAttribute('name') : $this->stack[$i]->getNode('filter')->getAttribute('value');
                     if ($name === 'desc' || $name === 'meaning') {
                         $arguments = iterator_to_array($this->stack[$i]->getNode('arguments'));
                         if (! isset($arguments[0])) {

--- a/Twig/DefaultApplyingNodeVisitor.php
+++ b/Twig/DefaultApplyingNodeVisitor.php
@@ -59,13 +59,12 @@ class DefaultApplyingNodeVisitor implements NodeVisitorInterface
 
         if (
             $node instanceof FilterExpression
-                && 'desc' === $node->getNode('filter')->getAttribute('value')
+                && 'desc' === ($node->hasAttribute('name') ? $node->getAttribute('name') : $node->getNode('filter')->getAttribute('value'))
         ) {
             $transNode = $node->getNode('node');
             while (
                 $transNode instanceof FilterExpression
-                       && 'trans' !== $transNode->getNode('filter')->getAttribute('value')
-                       && 'transchoice' !== $transNode->getNode('filter')->getAttribute('value')
+                    && !in_array($transNode->hasAttribute('name') ? $transNode->getAttribute('name') : $transNode->getNode('filter')->getAttribute('value'), ['trans', 'transchoice'], true)
             ) {
                 $transNode = $transNode->getNode('node');
             }
@@ -83,7 +82,7 @@ class DefaultApplyingNodeVisitor implements NodeVisitorInterface
             // if the |transchoice filter is used, delegate the call to the TranslationExtension
             // so that we can catch a possible exception when the default translation has not yet
             // been extracted
-            if ('transchoice' === $transNode->getNode('filter')->getAttribute('value')) {
+            if ('transchoice' === ($transNode->hasAttribute('name') ? $transNode->getAttribute('name') : $transNode->getNode('filter')->getAttribute('value'))) {
                 $transchoiceArguments = new ArrayExpression([], $transNode->getTemplateLine());
                 $transchoiceArguments->addElement($wrappingNode->getNode('node'));
                 $transchoiceArguments->addElement($defaultNode);

--- a/Twig/RemovingNodeVisitor.php
+++ b/Twig/RemovingNodeVisitor.php
@@ -45,7 +45,7 @@ class RemovingNodeVisitor implements NodeVisitorInterface
     public function enterNode(Node $node, Environment $env): Node
     {
         if ($this->enabled && $node instanceof FilterExpression) {
-            $name = $node->getNode('filter')->getAttribute('value');
+            $name = $node->hasAttribute('name') ? $node->getAttribute('name') : $node->getNode('filter')->getAttribute('value');
 
             if ('desc' === $name || 'meaning' === $name) {
                 return $this->enterNode($node->getNode('node'), $env);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | Apache2


## Description
Avoid deprecations triggered by twig 3.12 while keeping backward compatibility

Here's the deprecations it fixes:
```
Since twig/twig 3.12: Getting node "filter" on a "Twig\Node\Expression\FilterExpression" class is deprecated.
Since twig/twig 3.12: Getting node "filter" on a "Twig\Node\Expression\Filter\RawFilter" class is deprecated.
```
