### PR TITLE
Remove kernel.root_dir usages

### DIFF
--- a/Command/ResourcesListCommand.php
+++ b/Command/ResourcesListCommand.php
@@ -34,18 +34,12 @@ class ResourcesListCommand extends Command
 {
     private string $projectDir;
 
-    /**
-     * @var string|null
-     */
-    private $rootDir;
-
     private array $bundles;
 
-    public function __construct(string $projectDir, array $bundles, ?string $rootDir)
+    public function __construct(string $projectDir, array $bundles)
     {
         $this->projectDir = $projectDir;
         $this->bundles = $bundles;
-        $this->rootDir = $rootDir;
 
         parent::__construct();
     }
@@ -61,22 +55,14 @@ class ResourcesListCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $directoriesToSearch = [];
-
-        // TODO: Remove this block when dropping support of Symfony 4 as it will always be false
-        if ($this->rootDir !== null) {
-            $directoriesToSearch[] = realpath($this->rootDir);
-        }
-
         $basePath = realpath($this->projectDir);
-
         $directoriesToSearch[] = $basePath;
-
         $dirs = $this->retrieveDirs();
 
         if (!$input->hasParameterOption('--files')) {
             $output->writeln('<info>Directories list :</info>');
             foreach ($dirs as $dir) {
-                $path = str_replace($directoriesToSearch, ['%kernel.root_dir%', '%kernel.project_dir%'], $dir);
+                $path = str_replace($directoriesToSearch, ['%kernel.project_dir%'], $dir);
                 $output->writeln(sprintf('    - %s', $path));
             }
 
@@ -126,14 +112,6 @@ class ResourcesListCommand extends Command
             if (is_dir($dir = dirname($reflection->getFilename()) . '/Resources/translations')) {
                 $dirs[] = $dir;
             }
-        }
-
-        // TODO: Remove this block when dropping support of Symfony 4
-        if (
-            $this->rootDir !== null &&
-            is_dir($dir = $this->rootDir . '/Resources/translations')
-        ) {
-            $dirs[] = $dir;
         }
 
         if (is_dir($dir = $this->projectDir . '/translations')) {

--- a/Resources/config/console.xml
+++ b/Resources/config/console.xml
@@ -16,7 +16,6 @@
             <tag name="console.command" command="jms:translation:list-resources" />
             <argument>%kernel.project_dir%</argument>
             <argument>%kernel.bundles%</argument>
-            <argument type="expression">container.hasParameter('kernel.root_dir') ? parameter('kernel.root_dir') : null</argument>
         </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -66,7 +66,7 @@
         <service id="jms_translation.config_factory" class="%jms_translation.config_factory.class%" public="true"/>
 
         <service id="jms_translation.file_source_factory" class="%jms_translation.file_source_factory.class%">
-            <argument type="expression">container.hasParameter('kernel.root_dir') ? parameter('kernel.root_dir') : parameter('kernel.project_dir')</argument>
+            <argument>%kernel.project_dir%</argument>
             <argument>%kernel.project_dir%</argument>
         </service>
 

--- a/Tests/Functional/Command/ResourcesListCommandTest.php
+++ b/Tests/Functional/Command/ResourcesListCommandTest.php
@@ -33,7 +33,7 @@ final class ResourcesListCommandTest extends BaseCommandTestCase
 
         $expectedOutput =
             'Directories list :' . "\n"
-           . '    - %kernel.root_dir%/Fixture/TestBundle/Resources/translations' . "\n"
+           . '    - %kernel.project_dir%/Fixture/TestBundle/Resources/translations' . "\n"
            . 'done!' . "\n";
 
         $this->getApp()->run($input, $output = new Output());

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "php": "^8.1",
         "nikic/php-parser": "^5",
         "symfony/console": "^5.4 || ^6.4",
-        "symfony/expression-language": "^5.4 || ^6.4",
         "symfony/framework-bundle": "^5.4 || ^6.4",
         "symfony/config": "^5.4 || ^6.4 || ^7.1",
         "symfony/translation": "^5.4 || ^6.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | Apache2


## Description
Remove `kernel.root_dir` and always use `kernel.project_dir` as always available as per symfony versions requirements.
This allows to drop the requirement on `symfony/expression-language` which was introduced for the `expression` argument in dependency injection

