### PR TITLE
Remove legacy class support on validator extractor

### DIFF
--- a/Translation/Extractor/File/ValidationExtractor.php
+++ b/Translation/Extractor/File/ValidationExtractor.php
@@ -26,9 +26,7 @@ use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
-use Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
-use Symfony\Component\Validator\MetadataFactoryInterface as LegacyMetadataFactoryInterface;
 use Twig\Node\Node as TwigNode;
 
 /**
@@ -38,37 +36,23 @@ use Twig\Node\Node as TwigNode;
  */
 class ValidationExtractor implements FileVisitorInterface, NodeVisitor
 {
-    /**
-     * @var ClassMetadataFactoryInterface|MetadataFactoryInterface|LegacyMetadataFactoryInterface
-     */
-    private $metadataFactory;
+    private MetadataFactoryInterface $metadataFactory;
 
-    /**
-     * @var NodeTraverser
-     */
-    private $traverser;
+    private NodeTraverser $traverser;
 
     /**
      * @var MessageCatalogue
      */
     private $catalogue;
 
-    /**
-     * @var string
-     */
-    private $namespace = '';
+    private string $namespace = '';
 
     public function __construct($metadataFactory)
     {
-        if (
-            ! (
-            $metadataFactory instanceof MetadataFactoryInterface
-            || $metadataFactory instanceof LegacyMetadataFactoryInterface
-            || $metadataFactory instanceof ClassMetadataFactoryInterface
-            )
-        ) {
+        if (!$metadataFactory instanceof MetadataFactoryInterface) {
             throw new \InvalidArgumentException(sprintf('%s expects an instance of MetadataFactoryInterface or ClassMetadataFactoryInterface', static::class));
         }
+
         $this->metadataFactory = $metadataFactory;
 
         $this->traverser = new NodeTraverser();
@@ -100,8 +84,8 @@ class ValidationExtractor implements FileVisitorInterface, NodeVisitor
             return;
         }
 
-        $metadata = $this->metadataFactory instanceof ClassMetadataFactoryInterface ? $this->metadataFactory->getClassMetadata($name) : $this->metadataFactory->getMetadataFor($name);
-        if (!$metadata->hasConstraints() && !count($metadata->getConstrainedProperties())) {
+        $metadata = $this->metadataFactory->getMetadataFor($name);
+        if (!$metadata->getConstraints() && !$metadata->getConstrainedProperties()) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | Apache2


## Description
These classes are not available anymore since Symfony 3.x
