### PR TITLE
Remove php parser dead code

### DIFF
--- a/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
+++ b/Tests/Translation/Extractor/File/BasePhpFileExtractorTest.php
@@ -27,8 +27,6 @@ use JMS\TranslationBundle\Annotation\Meaning;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use JMS\TranslationBundle\Translation\FileSourceFactory;
-use PhpParser\Lexer;
-use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -45,14 +43,7 @@ abstract class BasePhpFileExtractorTest extends TestCase
             $extractor = $this->getDefaultExtractor();
         }
 
-        $lexer = new Lexer();
-        if (class_exists(ParserFactory::class)) {
-            $factory = new ParserFactory();
-            $parser  = \method_exists($factory, 'create') ? $factory->create(ParserFactory::PREFER_PHP7, $lexer) : $factory->createForNewestSupportedVersion();
-        } else {
-            $parser = new Parser($lexer);
-        }
-
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
         $ast = $parser->parse(file_get_contents($fileRealPath));
 
         $catalogue = new MessageCatalogue();

--- a/Tests/Translation/Extractor/File/TranslationContainerExtractorTest.php
+++ b/Tests/Translation/Extractor/File/TranslationContainerExtractorTest.php
@@ -25,8 +25,6 @@ use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\File\TranslationContainerExtractor;
-use PhpParser\Lexer;
-use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -59,14 +57,7 @@ class TranslationContainerExtractorTest extends TestCase
             $extractor = new TranslationContainerExtractor();
         }
 
-        $lexer = new Lexer();
-        if (class_exists(ParserFactory::class)) {
-            $factory = new ParserFactory();
-            $parser  = \method_exists($factory, 'create') ? $factory->create(ParserFactory::PREFER_PHP7, $lexer) : $factory->createForNewestSupportedVersion();
-        } else {
-            $parser = new Parser($lexer);
-        }
-
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
         $ast = $parser->parse(file_get_contents($fileRealPath));
 
         $catalogue = new MessageCatalogue();

--- a/Tests/Translation/Extractor/File/ValidationExtractorTest.php
+++ b/Tests/Translation/Extractor/File/ValidationExtractorTest.php
@@ -25,8 +25,6 @@ use JMS\TranslationBundle\Exception\RuntimeException;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\File\ValidationExtractor;
-use PhpParser\Lexer;
-use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
@@ -59,14 +57,7 @@ class ValidationExtractorTest extends TestCase
             $extractor = new ValidationExtractor($factory);
         }
 
-        $lexer = new Lexer();
-        if (class_exists(ParserFactory::class)) {
-            $factory = new ParserFactory();
-            $parser  = \method_exists($factory, 'create') ? $factory->create(ParserFactory::PREFER_PHP7, $lexer) : $factory->createForNewestSupportedVersion();
-        } else {
-            $parser = new Parser($lexer);
-        }
-
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
         $ast = $parser->parse(file_get_contents($fileRealPath));
 
         $catalogue = new MessageCatalogue();

--- a/Translation/Extractor/FileExtractor.php
+++ b/Translation/Extractor/FileExtractor.php
@@ -27,7 +27,6 @@ use JMS\TranslationBundle\Translation\ExtractorInterface;
 use JMS\TranslationBundle\Twig\DefaultApplyingNodeVisitor;
 use JMS\TranslationBundle\Twig\RemovingNodeVisitor;
 use PhpParser\Error;
-use PhpParser\Lexer;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use Psr\Log\LoggerInterface;
@@ -44,20 +43,11 @@ use Twig\Source;
  */
 class FileExtractor implements ExtractorInterface, LoggerAwareInterface
 {
-    /**
-     * @var Environment
-     */
-    private $twig;
+    private Environment $twig;
 
-    /**
-     * @var array
-     */
-    private $visitors;
+    private array $visitors;
 
-    /**
-     * @var Parser
-     */
-    private $phpParser;
+    private Parser $phpParser;
 
     /**
      * @var array
@@ -89,10 +79,7 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
      */
     private $excludedDirs = [];
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     /**
      * @param Environment $twig
@@ -104,13 +91,7 @@ class FileExtractor implements ExtractorInterface, LoggerAwareInterface
         $this->twig = $twig;
         $this->visitors = $visitors;
         $this->setLogger($logger);
-        $lexer = new Lexer();
-        if (class_exists(ParserFactory::class)) {
-            $factory = new ParserFactory();
-            $this->phpParser = \method_exists($factory, 'create') ? $factory->create(ParserFactory::PREFER_PHP7, $lexer) : $factory->createForNewestSupportedVersion();
-        } else {
-            $this->phpParser = new Parser($lexer);
-        }
+        $this->phpParser = (new ParserFactory())->createForNewestSupportedVersion();
 
         foreach ($this->twig->getNodeVisitors() as $visitor) {
             if ($visitor instanceof RemovingNodeVisitor) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | Apache2


## Description
As `nikic/php-parser` minimum version is `5.x`, let's clean the code.
