### PR TITLE
Remove twig trans node backward compatibility

### DIFF
--- a/Translation/Extractor/File/TwigFileExtractor.php
+++ b/Translation/Extractor/File/TwigFileExtractor.php
@@ -73,9 +73,9 @@ class TwigFileExtractor implements FileVisitorInterface, NodeVisitorInterface
         if ($node instanceof TransNode) {
             $id = $node->getNode('body')->getAttribute('data');
             $domain = 'messages';
-            // Older version of Symfony are storing null in the node instead of omitting it
-            if ($node->hasNode('domain') && null !== $domainNode = $node->getNode('domain')) {
-                $domain = $domainNode->getAttribute('value');
+
+            if ($node->hasNode('domain')) {
+                $domain = $node->getNode('domain')->getAttribute('value');
             }
 
             $message = new Message($id, $domain);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | Apache2

Removing this code is safe as it was fixed there : https://github.com/symfony/symfony/pull/19983 for symfony versions older than the current supported here.
