### PR TITLE
Fixed Twig 3.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - "master"
+      - "2.x"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -22,8 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         symfony-version:
-          - '^5.4'
-          - '^6.4'
           - '^7.2'
         php-version:
           - '8.3'
@@ -33,7 +32,7 @@ jobs:
           - 'highest'
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@v6"
         with:
           fetch-depth: 2
 
@@ -45,13 +44,8 @@ jobs:
           tools: 'flex'
           ini-values: "zend.assertions=1"
 
-      - name: 'Remove sensio/framework-extra-bundle'
-        if: matrix.symfony-version == '^7.2'
-        run: |
-          composer remove --dev --no-update sensio/framework-extra-bundle
-
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
+        uses: "ramsey/composer-install@v4"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "${{ matrix.composer-options }}"

--- a/.github/workflows/coding-standards.yaml
+++ b/.github/workflows/coding-standards.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - "master"
+      - "2.x"
 
 jobs:
   coding-standards:
@@ -18,7 +19,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@v6"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -29,7 +30,7 @@ jobs:
           extensions: pdo_sqlite
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v3"
+        uses: "ramsey/composer-install@v4"
 
       - name: "Run PHP_CodeSniffer"
         run: "vendor/bin/phpcs"

--- a/Tests/Twig/BaseTwigTestCase.php
+++ b/Tests/Twig/BaseTwigTestCase.php
@@ -26,18 +26,39 @@ use Symfony\Bridge\Twig\Extension\TranslationExtension as SymfonyTranslationExte
 use Symfony\Component\Translation\IdentityTranslator;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
+use Twig\Node\Node;
 use Twig\Source;
 
 abstract class BaseTwigTestCase extends TestCase
 {
     final protected function parse($file, $debug = false): string
     {
-        $content = file_get_contents(__DIR__ . '/Fixture/' . $file);
+        $env = $this->createEnvironment($debug);
 
+        return $env->compile($this->parseTemplate($env, $file));
+    }
+
+    /**
+     * Returns the body of the parsed template, i.e. the AST as produced by the bundle's node visitors.
+     */
+    final protected function parseAst(string $file, bool $debug = false): Node
+    {
+        return $this->parseTemplate($this->createEnvironment($debug), $file);
+    }
+
+    private function createEnvironment(bool $debug): Environment
+    {
         $env = new Environment(new ArrayLoader([]));
-        $env->addExtension(new SymfonyTranslationExtension($translator = new IdentityTranslator()));
+        $env->addExtension(new SymfonyTranslationExtension(new IdentityTranslator()));
         $env->addExtension(new TranslationExtension(null, $debug));
 
-        return $env->compile($env->parse($env->tokenize(new Source($content, 'whatever')))->getNode('body'));
+        return $env;
+    }
+
+    private function parseTemplate(Environment $env, string $file): Node
+    {
+        $content = file_get_contents(__DIR__ . '/Fixture/' . $file);
+
+        return $env->parse($env->tokenize(new Source($content, 'whatever')))->getNode('body');
     }
 }

--- a/Tests/Twig/DefaultApplyingNodeVisitorTest.php
+++ b/Tests/Twig/DefaultApplyingNodeVisitorTest.php
@@ -29,4 +29,29 @@ class DefaultApplyingNodeVisitorTest extends BaseTwigTestCase
             $this->parse('apply_default_value.html.twig', true)
         );
     }
+
+    /**
+     * The visitor rewrites the "desc" filter into a Twig AST, which must be built with
+     * the current node classes so that compiling templates stays deprecation-free.
+     */
+    public function testApplyDoesNotTriggerDeprecations(): void
+    {
+        $deprecations = [];
+        set_error_handler(
+            static function (int $errno, string $message) use (&$deprecations): bool {
+                $deprecations[] = $message;
+
+                return true;
+            },
+            E_USER_DEPRECATED
+        );
+
+        try {
+            $this->parse('apply_default_value.html.twig', true);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $deprecations);
+    }
 }

--- a/Tests/Twig/DefaultApplyingNodeVisitorTest.php
+++ b/Tests/Twig/DefaultApplyingNodeVisitorTest.php
@@ -20,6 +20,14 @@ declare(strict_types=1);
 
 namespace JMS\TranslationBundle\Tests\Twig;
 
+use Twig\Node\Expression\Binary\EqualBinary;
+use Twig\Node\Expression\FilterExpression;
+use Twig\Node\Expression\Ternary\ConditionalTernary;
+use Twig\Node\Expression\TestExpression;
+use Twig\Node\Node;
+use Twig\Node\Nodes;
+use Twig\TwigFilter;
+
 class DefaultApplyingNodeVisitorTest extends BaseTwigTestCase
 {
     public function testApply(): void
@@ -31,27 +39,72 @@ class DefaultApplyingNodeVisitorTest extends BaseTwigTestCase
     }
 
     /**
-     * The visitor rewrites the "desc" filter into a Twig AST, which must be built with
-     * the current node classes so that compiling templates stays deprecation-free.
+     * The visitor replaces the "desc" filter with a hand-built AST. Twig deprecated the node classes
+     * and constructor signatures it used to rely on, so assert which node types are produced: a wrong
+     * choice still compiles to the expected output (see testApply) while emitting deprecations.
      */
-    public function testApplyDoesNotTriggerDeprecations(): void
+    public function testApplyBuildsAstWithNonDeprecatedNodes(): void
     {
-        $deprecations = [];
-        set_error_handler(
-            static function (int $errno, string $message) use (&$deprecations): bool {
-                $deprecations[] = $message;
+        $conditions = $this->findConditionalTernaries($this->parseAst('apply_default_value.html.twig', true));
 
-                return true;
-            },
-            E_USER_DEPRECATED
+        // one for "|trans|desc(...)", one for "|trans({...})|desc(...)"
+        self::assertCount(2, $conditions);
+
+        // the replacements are stripped from the left-hand side of the comparison, which means
+        // rebuilding the "trans" filter arguments: they must stay a node list Twig accepts
+        $comparison = $this->unwrapTest($conditions[1]->getNode('test'));
+        self::assertInstanceOf(EqualBinary::class, $comparison);
+        self::assertInstanceOf(Nodes::class, $comparison->getNode('left')->getNode('arguments'));
+
+        // the default value is wrapped in a "replace" filter, which since Twig 3.12 has to be
+        // created from the environment's TwigFilter instance instead of from the filter name
+        $replaceFilter = $this->unwrapEscape($conditions[1]->getNode('left'));
+        self::assertInstanceOf(FilterExpression::class, $replaceFilter);
+        self::assertSame('replace', $replaceFilter->getAttribute('name'));
+        self::assertTrue(
+            $replaceFilter->hasAttribute('twig_callable'),
+            'The "replace" filter was not created from a TwigFilter instance.'
         );
+        self::assertInstanceOf(TwigFilter::class, $replaceFilter->getAttribute('twig_callable'));
+        self::assertInstanceOf(Nodes::class, $replaceFilter->getNode('arguments'));
+    }
 
-        try {
-            $this->parse('apply_default_value.html.twig', true);
-        } finally {
-            restore_error_handler();
+    /**
+     * @return list<ConditionalTernary>
+     */
+    private function findConditionalTernaries(Node $node): array
+    {
+        $found = $node instanceof ConditionalTernary ? [$node] : [];
+
+        foreach ($node as $child) {
+            if ($child instanceof Node) {
+                $found = array_merge($found, $this->findConditionalTernaries($child));
+            }
         }
 
-        $this->assertSame([], $deprecations);
+        return $found;
+    }
+
+    /**
+     * Twig >= 3.21 wraps a ternary condition in a "true" test.
+     */
+    private function unwrapTest(Node $node): Node
+    {
+        return $node instanceof TestExpression ? $node->getNode('node') : $node;
+    }
+
+    /**
+     * The output escaper wraps both ternary branches in an "escape" filter.
+     */
+    private function unwrapEscape(Node $node): Node
+    {
+        while (
+            $node instanceof FilterExpression
+            && 'escape' === $node->getAttribute('name')
+        ) {
+            $node = $node->getNode('node');
+        }
+
+        return $node;
     }
 }

--- a/Twig/DefaultApplyingNodeVisitor.php
+++ b/Twig/DefaultApplyingNodeVisitor.php
@@ -24,8 +24,8 @@ use JMS\TranslationBundle\Exception\RuntimeException;
 use Twig\Environment;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\Binary\EqualBinary;
-use Twig\Node\Expression\ConditionalExpression;
 use Twig\Node\Expression\FilterExpression;
+use Twig\Node\Expression\Ternary\ConditionalTernary;
 use Twig\Node\Node;
 use Twig\NodeVisitor\NodeVisitorInterface;
 
@@ -95,7 +95,7 @@ class DefaultApplyingNodeVisitor implements NodeVisitorInterface
                 );
             }
 
-            $condition = new ConditionalExpression(
+            $condition = new ConditionalTernary(
                 new EqualBinary($testNode, $transNode->getNode('node'), $wrappingNode->getTemplateLine()),
                 $defaultNode,
                 clone $wrappingNode,

--- a/Twig/DefaultApplyingNodeVisitor.php
+++ b/Twig/DefaultApplyingNodeVisitor.php
@@ -25,7 +25,6 @@ use Twig\Environment;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\Binary\EqualBinary;
 use Twig\Node\Expression\ConditionalExpression;
-use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FilterExpression;
 use Twig\Node\Node;
 use Twig\NodeVisitor\NodeVisitorInterface;
@@ -90,7 +89,7 @@ class DefaultApplyingNodeVisitor implements NodeVisitorInterface
                 // wrap the default node in a |replace filter
                 $defaultNode = new FilterExpression(
                     $arguments[0],
-                    new ConstantExpression('replace', $lineno),
+                    $env->getFilter('replace'),
                     new Node([$wrappingNodeArguments[0]]),
                     $lineno
                 );

--- a/Twig/DefaultApplyingNodeVisitor.php
+++ b/Twig/DefaultApplyingNodeVisitor.php
@@ -27,6 +27,7 @@ use Twig\Node\Expression\Binary\EqualBinary;
 use Twig\Node\Expression\FilterExpression;
 use Twig\Node\Expression\Ternary\ConditionalTernary;
 use Twig\Node\Node;
+use Twig\Node\Nodes;
 use Twig\NodeVisitor\NodeVisitorInterface;
 
 /**
@@ -84,13 +85,13 @@ class DefaultApplyingNodeVisitor implements NodeVisitorInterface
                 // remove the replacements from the test node
                 $testNodeArguments    = iterator_to_array($testNode->getNode('arguments'));
                 $testNodeArguments[0] = new ArrayExpression([], $lineno);
-                $testNode->setNode('arguments', new Node($testNodeArguments));
+                $testNode->setNode('arguments', new Nodes($testNodeArguments));
 
                 // wrap the default node in a |replace filter
                 $defaultNode = new FilterExpression(
                     $arguments[0],
                     $env->getFilter('replace'),
-                    new Node([$wrappingNodeArguments[0]]),
+                    new Nodes([$wrappingNodeArguments[0]]),
                     $lineno
                 );
             }

--- a/Twig/DefaultApplyingNodeVisitor.php
+++ b/Twig/DefaultApplyingNodeVisitor.php
@@ -87,10 +87,15 @@ class DefaultApplyingNodeVisitor implements NodeVisitorInterface
                 $testNodeArguments[0] = new ArrayExpression([], $lineno);
                 $testNode->setNode('arguments', new Nodes($testNodeArguments));
 
+                $replaceFilter = $env->getFilter('replace');
+                if (null === $replaceFilter) {
+                    throw new RuntimeException(sprintf('The "replace" filter, required by the "desc" filter in "%s" line %d, is not available.', $node->getTemplateName(), $node->getTemplateLine()));
+                }
+
                 // wrap the default node in a |replace filter
                 $defaultNode = new FilterExpression(
                     $arguments[0],
-                    $env->getFilter('replace'),
+                    $replaceFilter,
                     new Nodes([$wrappingNodeArguments[0]]),
                     $lineno
                 );

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jms/translation-bundle",
+    "name": "ibexa/translation-bundle",
     "type": "symfony-bundle",
     "description": "Puts the Symfony Translation Component on steroids",
     "keywords": [
@@ -20,6 +20,9 @@
             "email": "schmittjoh@gmail.com"
         }
     ],
+    "replace": {
+        "jms/translation-bundle": "^2.6"
+    },
     "require": {
         "php": "^8.1",
         "nikic/php-parser": "^5",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "nyholm/nsa": "^1.0.1",
         "phpunit/phpunit": "^11.5",
         "symfony/phpunit-bridge": "^7.2",
-        "sensio/framework-extra-bundle": "^6.2.4",
         "symfony/asset": "^5.4 || ^6.4 || ^7.1",
         "symfony/browser-kit": "^5.4 || ^6.4 || ^7.1",
         "symfony/css-selector": "^5.4 || ^6.4 || ^7.1",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/translation": "^5.4 || ^6.4 || ^7.1",
         "symfony/translation-contracts": "^2.0 || ^3.0",
         "symfony/validator": "^5.4 || ^6.4 || ^7.1",
-        "twig/twig": "^3.15",
+        "twig/twig": "^3.17",
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | no
| Fixed tickets | 
| License       | Apache2


## Description

This PR fix the following Twig 3.x deprecations in triggered by `\JMS\TranslationBundle\Twig\DefaultApplyingNodeVisitor`:

* Since twig/twig 3.12: Not 1passing an instance of "TwigFilter" when creating a "replace" filter of type "Twig\Node\Expression\FilterExpression" is deprecated.
* Since twig/twig 3.15: Instantiating "Twig\Node\Node" directly is deprecated; the class will become abstract in 4.0.
* Since twig/twig 3.17: "Twig\Node\Expression\ConditionalExpression" is deprecated; use "Twig\Node\Expression\Ternary\ConditionalTernary" instead.

![image](https://github.com/user-attachments/assets/8edb7c22-9834-4a5d-8915-73ddc380d99a)

PR is still work in progress. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
