### PR TITLE
Add support for extracting translations from Symfony Form 'help' options

### DIFF
--- a/Tests/Translation/Extractor/File/Fixture/MyHelpFormType.php
+++ b/Tests/Translation/Extractor/File/Fixture/MyHelpFormType.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\TranslationBundle\Tests\Translation\Extractor\File\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class MyHelpFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('field_with_attr_help', 'text', [
+                'label' => 'field.with.help',
+                'help' => /** @Desc("Field with a help value") */ 'form.help.text',
+            ])
+            ->add('field_without_label_with_attr_help', 'text', [
+                'label' => false,
+                'help' => /** @Desc("Field with a help but no label") */ 'form.help.text.but.no.label',
+            ])
+            ->add('field_help', 'choice', [
+                'help' => /** @Desc("Choice field with a help") */ 'form.choice_help'
+            ]);
+    }
+}

--- a/Tests/Translation/Extractor/File/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/File/FormExtractorTest.php
@@ -27,6 +27,37 @@ use JMS\TranslationBundle\Translation\Extractor\File\FormExtractor;
 class FormExtractorTest extends BasePhpFileExtractorTest
 {
     /**
+     * @group help
+     */
+    public function testHelpExtract()
+    {
+        $expected          = new MessageCatalogue();
+        $fileSourceFactory = $this->getFileSourceFactory();
+        $fixtureSplInfo    = new \SplFileInfo(__DIR__ . '/Fixture/MyHelpFormType.php');
+
+        $message = new Message('field.with.help');
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 32));
+        $expected->add($message);
+
+        $message = new Message('form.help.text');
+        $message->setDesc('Field with a help value');
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 33));
+        $expected->add($message);
+
+        $message = new Message('form.help.text.but.no.label');
+        $message->setDesc('Field with a help but no label');
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 37));
+        $expected->add($message);
+
+        $message = new Message('form.choice_help');
+        $message->setDesc('Choice field with a help');
+        $message->addSource($fileSourceFactory->create($fixtureSplInfo, 40));
+        $expected->add($message);
+
+        $this->assertEquals($expected, $this->extract('MyHelpFormType.php'));
+    }
+
+    /**
      * @group placeholder
      */
     public function testPlaceholderExtract()

--- a/Translation/Extractor/File/FormExtractor.php
+++ b/Translation/Extractor/File/FormExtractor.php
@@ -126,6 +126,7 @@ class FormExtractor implements FileVisitorInterface, LoggerAwareInterface, NodeV
 
                 switch ($item->key->value) {
                     case 'label':
+                    case 'help':
                         $this->parseItem($item, $domain);
                         break;
                     case 'invalid_message':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description
This PR adds 'help' to the FormExtractor, so it is picked up and registered as a translatable message. The help option was introduced in Symfony 4.1. Will it be possible to have this in 1.x?

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Changelog