### PR TITLE
Fixed Symfony 7.4 incompatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   phpunit:
     name: 'PHPUnit (PHP ${{ matrix.php-version }}, Symfony ${{ matrix.symfony-version }} + ${{ matrix.dependencies }} deps)'
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       fail-fast: false
@@ -33,7 +33,7 @@ jobs:
           - 'highest'
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v5"
         with:
           fetch-depth: 2
 

--- a/.github/workflows/coding-standards.yaml
+++ b/.github/workflows/coding-standards.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       matrix:
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v5"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -29,7 +29,7 @@ jobs:
           extensions: pdo_sqlite
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v3"
 
       - name: "Run PHP_CodeSniffer"
         run: "vendor/bin/phpcs"

--- a/Translation/Extractor/File/ValidationExtractor.php
+++ b/Translation/Extractor/File/ValidationExtractor.php
@@ -26,7 +26,9 @@ use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
+use Symfony\Component\Validator\Mapping\MetadataInterface;
 use Twig\Node\Node as TwigNode;
 
 /**
@@ -89,12 +91,8 @@ class ValidationExtractor implements FileVisitorInterface, NodeVisitor
             return;
         }
 
-        $this->extractFromConstraints($metadata->constraints);
-        foreach ($metadata->members as $members) {
-            foreach ($members as $member) {
-                $this->extractFromConstraints($member->constraints);
-            }
-        }
+        $this->extractFromConstraints($metadata->getConstraints());
+        $this->extractFromClassMetadata($metadata);
     }
 
     /**
@@ -175,6 +173,21 @@ class ValidationExtractor implements FileVisitorInterface, NodeVisitor
                         }
                     }
                 }
+            }
+        }
+    }
+
+    private function extractFromClassMetadata(MetadataInterface $metadata): void
+    {
+        if (!$metadata instanceof ClassMetadata) {
+            return;
+        }
+
+        foreach ($metadata->getConstrainedProperties() as $property) {
+            $memberMetadata = $metadata->getPropertyMetadata($property);
+            foreach ($memberMetadata as $metadata) {
+                $constraints = $metadata->getConstraints();
+                $this->extractFromConstraints($constraints);
             }
         }
     }

--- a/Translation/Extractor/File/ValidationExtractor.php
+++ b/Translation/Extractor/File/ValidationExtractor.php
@@ -185,8 +185,8 @@ class ValidationExtractor implements FileVisitorInterface, NodeVisitor
 
         foreach ($metadata->getConstrainedProperties() as $property) {
             $memberMetadata = $metadata->getPropertyMetadata($property);
-            foreach ($memberMetadata as $metadata) {
-                $constraints = $metadata->getConstraints();
+            foreach ($memberMetadata as $innerMetadata) {
+                $constraints = $innerMetadata->getConstraints();
                 $this->extractFromConstraints($constraints);
             }
         }

--- a/Translation/Extractor/File/ValidationExtractor.php
+++ b/Translation/Extractor/File/ValidationExtractor.php
@@ -26,7 +26,7 @@ use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\Mapping\MetadataInterface;
 use Twig\Node\Node as TwigNode;
@@ -179,7 +179,7 @@ class ValidationExtractor implements FileVisitorInterface, NodeVisitor
 
     private function extractFromClassMetadata(MetadataInterface $metadata): void
     {
-        if (!$metadata instanceof ClassMetadata) {
+        if (!$metadata instanceof ClassMetadataInterface) {
             return;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "doctrine/coding-standard": "^9.0",
         "matthiasnoback/symfony-dependency-injection-test": "^6.0",
         "nyholm/nsa": "^1.0.1",
+        "phpunit/phpunit": "^11.5",
         "symfony/phpunit-bridge": "^7.2",
         "sensio/framework-extra-bundle": "^6.2.4",
         "symfony/asset": "^5.4 || ^6.4 || ^7.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes? :sweat_smile: 
| Fixed tickets | 
| License       | Apache2


## Description
This PR changes how `ValidationExtractor` interacts with metadata returned from `MetadataFactory`, fixing an issue that shows up after recent Symfony 7.4 release.

Before, internal properties were used (which were only public to reduce serialization size). With these changes, Symfony 7.4 metadata - which now has private properties instead of public - should be handled properly.

All methods used in this new version are also present since at least Symfony 5.4, so they should be safe.

See:
 * https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Validator/Mapping/GenericMetadata.php#L192
 * https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Validator/Mapping/ClassMetadata.php#L386

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog
